### PR TITLE
feat: add LifeOS local data and project status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ Alle nennenswerten Änderungen an diesem Projekt werden in dieser Datei dokument
 
 Das Format orientiert sich an Keep a Changelog. Versionen folgen dem Projektstand B1 bis B6 und den Build Versionen von JARVIS.
 
+## [B6.6.1] - 2026-05-01
+
+### Added
+
+- Lokale LifeOS Beispielkonfiguration unter `config/lifeos.example.json`.
+- Beispielstruktur für Daily Briefing, Work Radar, Life Modules, Timeline und Security Vorgaben.
+
+### Changed
+
+- LifeOS Dokumentation um lokale Datenstruktur und sicheren Umgang mit `config/lifeos.json` ergänzt.
+
+### Security
+
+- Persönliche lokale LifeOS Daten sollen nicht ins Repository committed werden.
+
 ## [B6.6.0] - 2026-05-01
 
 ### Added

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,0 +1,92 @@
+# JARVIS Projektstatus
+
+Diese Datei zeigt den aktuellen Stand des Projekts auf einen Blick. Sie ergänzt den Changelog.
+
+Der Changelog dokumentiert, was versioniert geändert wurde. Diese Datei zeigt zusätzlich, was noch offen ist und was als Nächstes sinnvoll ist.
+
+## Aktueller Stand
+
+| Bereich | Status | Hinweis |
+|---|---|---|
+| Repository Basis | erledigt | Projektstruktur, README, Changelog, Contribution Regeln und Security Hinweise vorhanden |
+| Launcher | erledigt | Startseite mit Global Overview, ULTRON Grid und LifeOS Einstieg vorhanden |
+| Global Overview | erledigt | Stabile Weltkarten Ansicht als lokaler HUD Prototyp vorhanden |
+| ULTRON Grid | erledigt | JARVIS und ULTRON Command Grid mit Modus Umschaltung vorhanden |
+| LifeOS Command Center | erledigt | Erste sichtbare LifeOS Oberfläche vorhanden |
+| LifeOS lokale Daten | in Arbeit | `config/lifeos.example.json` als sichere Beispielkonfiguration vorbereitet |
+| Installer | offen | Installer muss weiter auf echte Endanwender Robustheit geprüft werden |
+| Backend Integration | offen | LifeOS liest noch keine echten Daten aus Backend oder lokaler Runtime |
+| Tests und CI | vorhanden | CI ist angelegt, muss bei größeren Dependency Updates aufmerksam geprüft werden |
+
+## Erledigte Updates
+
+### B6.6.1
+
+- `config/lifeos.example.json` vorbereitet.
+- LifeOS Datenstruktur für Daily Briefing, Work Radar, Life Modules, Timeline und Security ergänzt.
+- Dokumentation um lokale LifeOS Daten erweitert.
+- Hinweis ergänzt, dass echte lokale Daten nicht ins Repository gehören.
+
+### B6.6.0
+
+- LifeOS Command Center Prototyp erstellt.
+- Launcher um LifeOS erweitert.
+- Dokumentation `docs/lifeos-global-upgrade.md` angelegt.
+- Changelog um LifeOS ergänzt.
+
+### B6.5.1
+
+- GitHub Actions CI ergänzt.
+- Release Workflow ergänzt.
+- Dependabot ergänzt.
+- Issue und Pull Request Templates ergänzt.
+- Changelog und Contribution Dokumentation ergänzt.
+- Installer Logik teilweise verbessert.
+
+## Offene Updates und Todos
+
+| Priorität | Thema | Status | Nächster Schritt |
+|---|---|---|---|
+| Hoch | LifeOS Daten laden | offen | Frontend soll Werte aus `config/lifeos.example.json` oder später Backend API verwenden |
+| Hoch | Daily Briefing Generator | offen | Kleine Logik bauen, die aus LifeOS Daten eine Tageslage erzeugt |
+| Hoch | Installer Prüfung | offen | Start, First Setup, Python Erkennung und PowerShell ExecutionPolicy erneut testen |
+| Mittel | Backend Health Check | offen | lokalen `/health` Check sauber mit Frontend und Installer verbinden |
+| Mittel | DiagCenter | offen | Diagnose Modul für Python, Node, Ports, Config und Logs konkretisieren |
+| Mittel | Work Radar | offen | Struktur für SAP, FSM, Mail, LNW und offene Rückfragen vorbereiten |
+| Mittel | Knowledge Index | offen | lokale Wissensstruktur für Notizen, Dokumente und Projektwissen definieren |
+| Niedrig | UI Feinschliff LifeOS | offen | Layout, Texte und Live Werte nach erstem lokalen Test nachschärfen |
+| Niedrig | Release ZIP | offen | GitHub Release Workflow mit echtem Tag testen |
+
+## Risiken
+
+| Risiko | Einschätzung | Empfehlung |
+|---|---|---|
+| Dependabot Major Updates | hoch | React, TypeScript, Vite und Actions Major Updates nicht blind mergen |
+| Zu viele UI Prototypen ohne Daten | mittel | Ab jetzt kleine echte Datenintegration vor weiterer Optik priorisieren |
+| Installer Fehler bei Endanwendern | hoch | Installer weiterhin als eigener Schwerpunkt behandeln |
+| Private Daten im Repo | hoch | echte lokale Dateien wie `config/lifeos.json` nicht committen |
+
+## Nächster sinnvoller Schritt
+
+LifeOS soll als Nächstes lokale Daten anzeigen. Dafür wird zuerst die Beispielkonfiguration genutzt. Danach kann eine echte lokale `config/lifeos.json` entstehen, die nicht ins Repository committed wird.
+
+Empfohlene Reihenfolge:
+
+```text
+1. LifeOS lokalen Daten Loader bauen
+2. Daily Briefing aus JSON erzeugen
+3. PROJECT_STATUS.md nach jedem größeren Schritt aktualisieren
+4. Installer Robustheit erneut prüfen
+5. Erst danach größere Dependency Updates angehen
+```
+
+## Pflege Regel
+
+Diese Datei sollte bei jedem größeren Projektstand aktualisiert werden.
+
+Kurzregel:
+
+```text
+Changelog = was wurde versioniert geändert
+PROJECT_STATUS = was ist erledigt, was ist offen, was kommt als Nächstes
+```

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -4,6 +4,26 @@ Diese Datei zeigt den aktuellen Stand des Projekts auf einen Blick. Sie ergänzt
 
 Der Changelog dokumentiert, was versioniert geändert wurde. Diese Datei zeigt zusätzlich, was noch offen ist und was als Nächstes sinnvoll ist.
 
+## Verbindliche Pflege Regel
+
+Bei jedem größeren Schritt im Projekt müssen zwei Dateien geprüft und bei Bedarf aktualisiert werden:
+
+```text
+CHANGELOG.md
+PROJECT_STATUS.md
+```
+
+Diese Regel gilt für neue Features, Fixes, UI Änderungen, Installer Änderungen, Dokumentation, Release Vorbereitungen und größere Dependency Updates.
+
+Kurzregel:
+
+```text
+Changelog = was wurde versioniert geändert
+PROJECT_STATUS = was ist erledigt, was ist offen, was kommt als Nächstes
+```
+
+Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS.md` nicht geprüft wurde.
+
 ## Aktueller Stand
 
 | Bereich | Status | Hinweis |
@@ -26,6 +46,7 @@ Der Changelog dokumentiert, was versioniert geändert wurde. Diese Datei zeigt z
 - LifeOS Datenstruktur für Daily Briefing, Work Radar, Life Modules, Timeline und Security ergänzt.
 - Dokumentation um lokale LifeOS Daten erweitert.
 - Hinweis ergänzt, dass echte lokale Daten nicht ins Repository gehören.
+- Verbindliche Pflege Regel für `CHANGELOG.md` und `PROJECT_STATUS.md` ergänzt.
 
 ### B6.6.0
 
@@ -80,13 +101,14 @@ Empfohlene Reihenfolge:
 5. Erst danach größere Dependency Updates angehen
 ```
 
-## Pflege Regel
+## Pflege Ablauf
 
-Diese Datei sollte bei jedem größeren Projektstand aktualisiert werden.
-
-Kurzregel:
+Vor jedem Commit oder Pull Request prüfen:
 
 ```text
-Changelog = was wurde versioniert geändert
-PROJECT_STATUS = was ist erledigt, was ist offen, was kommt als Nächstes
+1. Wurde etwas Nutzer sichtbares geändert?
+2. Wurde ein technischer Meilenstein erreicht?
+3. Hat sich ein offener Punkt erledigt?
+4. Ist ein neues Risiko oder Todo entstanden?
+5. Müssen CHANGELOG.md und PROJECT_STATUS.md angepasst werden?
 ```

--- a/config/lifeos.example.json
+++ b/config/lifeos.example.json
@@ -1,0 +1,85 @@
+{
+  "version": "B6.6.1",
+  "mode": "local-first",
+  "daily_briefing": {
+    "day_mode": "FOCUSED",
+    "priority_count": 3,
+    "focus_minutes": 92,
+    "open_loops": 7,
+    "energy_percent": 81,
+    "today_important": [
+      "Offene Rückfragen aus Arbeit und Abrechnung prüfen",
+      "LNW und FSM Buchungen auf fehlende Nachweise kontrollieren",
+      "Einen Lernblock oder Projektblock für den Nachmittag reservieren"
+    ],
+    "next_best_action": "Zuerst die offenen Rückfragen mit hoher Außenwirkung schließen, danach LifeOS oder Lernblock weiterführen."
+  },
+  "work_radar": {
+    "lnw_and_billing": {
+      "status": "check",
+      "score_percent": 72,
+      "note": "Leistungsnachweise und abrechnungsrelevante Themen zuerst prüfen."
+    },
+    "fsm_bookings": {
+      "status": "stable",
+      "score_percent": 84,
+      "note": "FSM Buchungen weiter sauber halten, nicht mit CATS mischen."
+    },
+    "customer_topics": {
+      "status": "attention",
+      "open_count": 2,
+      "score_percent": 38,
+      "note": "Offene Kundenrückfragen aktiv schließen."
+    },
+    "vde_dguv_research": {
+      "status": "ready",
+      "note": "Normenrecherche für Angebote und Prüftexte verfügbar."
+    }
+  },
+  "life_modules": [
+    {
+      "name": "Work",
+      "description": "SAP, FSM, Mail, LNW, Angebote und offene Klärungen"
+    },
+    {
+      "name": "Learn",
+      "description": "Meister, AEVO, Wiederholungen und Schwachstellen"
+    },
+    {
+      "name": "Health",
+      "description": "Pausen, Energie, Konzentration und Belastung"
+    },
+    {
+      "name": "Private",
+      "description": "Verträge, Finanzen, Termine und persönliche Projekte"
+    }
+  ],
+  "timeline": [
+    {
+      "time": "07:30",
+      "title": "Daily Scan",
+      "tag": "auto"
+    },
+    {
+      "time": "09:00",
+      "title": "Arbeits Radar prüfen",
+      "tag": "work"
+    },
+    {
+      "time": "12:30",
+      "title": "kurzer Reset",
+      "tag": "energy"
+    },
+    {
+      "time": "16:10",
+      "title": "Lernblock oder Projektblock",
+      "tag": "focus"
+    }
+  ],
+  "security": {
+    "external_telemetry": false,
+    "microphone_default": "off",
+    "secrets_allowed": false,
+    "private_paths_allowed": false
+  }
+}

--- a/docs/lifeos-global-upgrade.md
+++ b/docs/lifeos-global-upgrade.md
@@ -31,6 +31,18 @@ Heute wichtig:
 4. Private Fristen und Termine abgleichen
 ```
 
+## Lokale Beispielkonfiguration
+
+Die Datei `config/lifeos.example.json` beschreibt den ersten lokalen Datensatz für LifeOS. Sie enthält bewusst nur Beispielwerte und keine privaten Daten.
+
+Für echte lokale Nutzung kann daraus später eine nicht versionierte Datei entstehen:
+
+```text
+config/lifeos.json
+```
+
+Diese echte lokale Datei darf nicht mit persönlichen Daten ins Repository committed werden.
+
 ## Datenprinzip
 
 LifeOS bleibt Local First.
@@ -54,6 +66,7 @@ lifeos/
   schemas.py
 
 config/
+  lifeos.example.json
   lifeos.json
 ```
 
@@ -62,8 +75,9 @@ config/
 1. LifeOS Command Center als lokale Single File Ansicht
 2. Launcher Eintrag für LifeOS
 3. Dokumentation des Zielbilds
-4. später: lokale JSON Demo Daten
-5. danach: Backend Schnittstelle für echtes Daily Briefing
+4. lokale JSON Beispiel Daten
+5. danach: Frontend Loader für lokale Werte
+6. danach: Backend Schnittstelle für echtes Daily Briefing
 
 ## Akzeptanzkriterien für die nächste Stufe
 


### PR DESCRIPTION
## Beschreibung

Ergänzt die erste lokale Beispielkonfiguration für LifeOS und eine zentrale Projektstatus Datei.

## Änderungen

- Neue Datei `config/lifeos.example.json`
- Neue Datei `PROJECT_STATUS.md`
- Daily Briefing Beispielwerte
- Work Radar Beispielstruktur
- Life Modules und Timeline
- Security Vorgaben für Local First Nutzung
- Dokumentation in `docs/lifeos-global-upgrade.md` erweitert
- Changelog Eintrag `B6.6.1`

## Warum PROJECT_STATUS.md?

Der Changelog dokumentiert versionierte Änderungen. `PROJECT_STATUS.md` zeigt zusätzlich:

- was bereits erledigt ist
- was noch offen ist
- welche Risiken bestehen
- was als nächstes sinnvoll ist

## Sicherheit

- Nur Beispielwerte enthalten
- Keine Secrets
- Keine privaten Pfade
- Keine Kundendaten
- Echte lokale Datei `config/lifeos.json` soll später nicht ins Repo committed werden