### PR TITLE
feat: add LifeOS personal config setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ Alle nennenswerten Änderungen an diesem Projekt werden in dieser Datei dokument
 
 Das Format orientiert sich an Keep a Changelog. Versionen folgen dem Projektstand B1 bis B6 und den Build Versionen von JARVIS.
 
+## [B6.6.6] - 2026-05-01
+
+### Added
+
+- PowerShell Setup Skript `scripts/maintenance/setup-lifeos-config.ps1` ergänzt.
+- Dokumentation `docs/lifeos-private-config.md` ergänzt.
+- Skript erzeugt eine private lokale `config/lifeos.json` aus `config/lifeos.example.json`.
+
+### Changed
+
+- LifeOS persönliche Vorlage ist jetzt als konkreter Setup Schritt vorbereitet.
+
+### Security
+
+- Das Skript überschreibt eine bestehende `config/lifeos.json` nur mit `-Force`.
+- Private LifeOS Daten bleiben lokal und werden weiterhin nicht committed.
+
 ## [B6.6.5] - 2026-05-01
 
 ### Added

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -37,11 +37,20 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 | LifeOS Daily Briefing | erledigt | LifeOS erzeugt eine erste Tageslage aus Prioritäten, offenen Schleifen, Energie, Fokuszeit und Work Radar |
 | LifeOS private Config | erledigt | `config/lifeos.json` wird bevorzugt geladen und über `.gitignore` aus dem Repository gehalten |
 | LifeOS Roadmap | erledigt | Ausgearbeitete Upgrade Roadmap liegt unter `docs/lifeos-roadmap.md` |
+| LifeOS persönliche Vorlage | erledigt | Skript und Anleitung zum Erzeugen der privaten `config/lifeos.json` vorhanden |
 | Installer | offen | Installer muss weiter auf echte Endanwender Robustheit geprüft werden |
 | Backend Integration | offen | LifeOS liest noch keine echten Daten aus Backend oder lokaler Runtime |
 | Tests und CI | vorhanden | CI ist angelegt, muss bei größeren Dependency Updates aufmerksam geprüft werden |
 
 ## Erledigte Updates
+
+### B6.6.6
+
+- Setup Skript `scripts/maintenance/setup-lifeos-config.ps1` ergänzt.
+- Dokumentation `docs/lifeos-private-config.md` ergänzt.
+- Skript kopiert `config/lifeos.example.json` nach `config/lifeos.json`.
+- Bestehende private Konfiguration wird nur mit `-Force` überschrieben.
+- Changelog und PROJECT_STATUS gemäß Pflege Regel aktualisiert.
 
 ### B6.6.5
 
@@ -99,7 +108,6 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 
 | Priorität | Thema | Status | Nächster Schritt |
 |---|---|---|---|
-| Hoch | LifeOS persönliche Vorlage | offen | Anleitung oder Kopierskript für `config/lifeos.json` aus `config/lifeos.example.json` ergänzen |
 | Hoch | Daily Command Center | offen | Top 3 Aufgaben, Tagesfokus und klaren nächsten Schritt aus lokalen Daten ableiten |
 | Hoch | Work Radar 2.0 | offen | strukturierte Vorgänge für SAP, FSM, LNW, Mail, Angebote und Rückfragen ergänzen |
 | Hoch | Installer Prüfung | offen | Start, First Setup, Python Erkennung und PowerShell ExecutionPolicy erneut testen |
@@ -122,6 +130,7 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 |---|---|
 | `docs/lifeos-roadmap.md` | Ausgearbeitete LifeOS Upgrade Roadmap mit Modulen, Nutzen, Umsetzung und Akzeptanzkriterien |
 | `docs/lifeos-global-upgrade.md` | Grundkonzept des LifeOS Global Upgrade |
+| `docs/lifeos-private-config.md` | Anleitung für die private lokale LifeOS Konfiguration |
 | `CHANGELOG.md` | Versionierte Änderungen |
 | `PROJECT_STATUS.md` | Projektstand, offene Todos, Risiken und nächster sinnvoller Schritt |
 
@@ -137,16 +146,16 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 
 ## Nächster sinnvoller Schritt
 
-Nach der Roadmap ist der nächste sinnvolle Schritt die LifeOS persönliche Vorlage. Damit kann lokal aus `config/lifeos.example.json` eine echte private `config/lifeos.json` erzeugt werden, ohne persönliche Daten ins Repository zu schreiben.
+Nach der persönlichen LifeOS Vorlage ist der nächste sinnvolle Schritt das Daily Command Center. Dafür soll LifeOS aus lokalen Daten Top 3 Aufgaben, Tagesfokus und einen klaren nächsten Schritt ableiten.
 
 Empfohlene Reihenfolge:
 
 ```text
-1. Anleitung oder Skript für config/lifeos.json ergänzen
-2. Daily Command Center um Top 3 Aufgaben erweitern
-3. Work Radar 2.0 Schema ergänzen
-4. Installer Robustheit erneut prüfen
-5. Backend Health Check sauber anbinden
+1. Daily Command Center um Top 3 Aufgaben erweitern
+2. Work Radar 2.0 Schema ergänzen
+3. Installer Robustheit erneut prüfen
+4. Backend Health Check sauber anbinden
+5. DiagCenter konkretisieren
 ```
 
 ## Pflege Ablauf

--- a/docs/lifeos-private-config.md
+++ b/docs/lifeos-private-config.md
@@ -1,0 +1,61 @@
+# LifeOS private Konfiguration
+
+LifeOS kann persönliche lokale Daten aus `config/lifeos.json` laden. Diese Datei ist bewusst nicht Teil des Repositorys und wird über `.gitignore` ausgeschlossen.
+
+## Warum privat?
+
+`config/lifeos.json` kann später echte persönliche Daten enthalten, zum Beispiel Tagesplanung, private Projekte, Lernstände, Vertragsfristen oder Arbeitsnotizen. Solche Daten gehören nicht nach GitHub.
+
+## Datei erzeugen
+
+Unter Windows im Repository Root ausführen:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\maintenance\setup-lifeos-config.ps1
+```
+
+Das Skript kopiert:
+
+```text
+config/lifeos.example.json
+```
+
+nach:
+
+```text
+config/lifeos.json
+```
+
+Wenn `config/lifeos.json` bereits existiert, wird sie nicht überschrieben.
+
+## Datei neu erzeugen
+
+Nur wenn die bestehende private Datei bewusst überschrieben werden soll:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\maintenance\setup-lifeos-config.ps1 -Force
+```
+
+## Lade Reihenfolge in LifeOS
+
+LifeOS nutzt diese Reihenfolge:
+
+```text
+1. config/lifeos.json
+2. config/lifeos.example.json
+3. interner Fallback im HTML
+```
+
+## Sicherheitsregel
+
+```text
+config/lifeos.json niemals committen
+```
+
+Vor jedem Commit prüfen:
+
+```powershell
+git status
+```
+
+Wenn `config/lifeos.json` auftaucht, darf sie nicht eingecheckt werden.

--- a/scripts/maintenance/setup-lifeos-config.ps1
+++ b/scripts/maintenance/setup-lifeos-config.ps1
@@ -1,0 +1,53 @@
+<#
+.SYNOPSIS
+Creates a private local LifeOS configuration from the safe example file.
+
+.DESCRIPTION
+This script copies config/lifeos.example.json to config/lifeos.json.
+The private config/lifeos.json file is ignored by Git and must stay local.
+The script will not overwrite an existing config/lifeos.json unless -Force is used.
+
+.EXAMPLE
+powershell -ExecutionPolicy Bypass -File scripts\maintenance\setup-lifeos-config.ps1
+
+.EXAMPLE
+powershell -ExecutionPolicy Bypass -File scripts\maintenance\setup-lifeos-config.ps1 -Force
+#>
+
+param(
+    [switch]$Force
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+$ConfigDir = Join-Path $RepoRoot "config"
+$ExampleFile = Join-Path $ConfigDir "lifeos.example.json"
+$PrivateFile = Join-Path $ConfigDir "lifeos.json"
+
+Write-Host "JARVIS LifeOS private config setup" -ForegroundColor Cyan
+Write-Host "Repository: $RepoRoot"
+
+if (-not (Test-Path $ExampleFile)) {
+    Write-Error "Missing example file: $ExampleFile"
+    exit 1
+}
+
+if (-not (Test-Path $ConfigDir)) {
+    New-Item -ItemType Directory -Path $ConfigDir | Out-Null
+}
+
+if ((Test-Path $PrivateFile) -and (-not $Force)) {
+    Write-Host "Private LifeOS config already exists:" -ForegroundColor Yellow
+    Write-Host "  $PrivateFile"
+    Write-Host "No file was overwritten. Use -Force if you really want to recreate it."
+    exit 0
+}
+
+Copy-Item -Path $ExampleFile -Destination $PrivateFile -Force:$Force
+
+Write-Host "Created private LifeOS config:" -ForegroundColor Green
+Write-Host "  $PrivateFile"
+Write-Host ""
+Write-Host "Next step: edit config\lifeos.json with your own local values."
+Write-Host "This file is ignored by Git and should not be committed."


### PR DESCRIPTION
## Beschreibung

Ergänzt den nächsten Roadmap Schritt: eine einfache persönliche LifeOS Vorlage für lokale private Daten.

## Änderungen

- Neues Skript `scripts/maintenance/setup-lifeos-config.ps1`
- Neue Dokumentation `docs/lifeos-private-config.md`
- CHANGELOG.md Eintrag `B6.6.6`
- PROJECT_STATUS.md gemäß Pflege Regel aktualisiert

## Funktion

Das Skript kopiert:

```text
config/lifeos.example.json
```

nach:

```text
config/lifeos.json
```

Eine bestehende private Datei wird nur mit `-Force` überschrieben.

## Sicherheit

- `config/lifeos.json` bleibt lokal
- Datei ist über `.gitignore` ausgeschlossen
- keine privaten Daten im Repo
- kein Überschreiben ohne bewusstes `-Force`