### PR TITLE
feat: add Daily Command Center data model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ Alle nennenswerten Änderungen an diesem Projekt werden in dieser Datei dokument
 
 Das Format orientiert sich an Keep a Changelog. Versionen folgen dem Projektstand B1 bis B6 und den Build Versionen von JARVIS.
 
+## [B6.7.0] - 2026-05-01
+
+### Added
+
+- Daily Command Center Datenfelder in `config/lifeos.example.json` ergänzt.
+- Neues Feld `daily_briefing.day_focus` für den Tagesfokus.
+- Neues Array `daily_briefing.top_tasks` für die drei wichtigsten Aufgaben mit Bereich, Wirkung, Aufwand und nächstem Schritt.
+- Dokumentation `docs/lifeos-daily-command-center.md` ergänzt.
+
+### Changed
+
+- LifeOS Datenmodell ist jetzt auf Tagesfokus und Top 3 Aufgaben vorbereitet.
+
 ## [B6.6.6] - 2026-05-01
 
 ### Added

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -38,11 +38,20 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 | LifeOS private Config | erledigt | `config/lifeos.json` wird bevorzugt geladen und über `.gitignore` aus dem Repository gehalten |
 | LifeOS Roadmap | erledigt | Ausgearbeitete Upgrade Roadmap liegt unter `docs/lifeos-roadmap.md` |
 | LifeOS persönliche Vorlage | erledigt | Skript und Anleitung zum Erzeugen der privaten `config/lifeos.json` vorhanden |
+| Daily Command Center Datenmodell | in Arbeit | Tagesfokus und Top 3 Aufgaben sind in der Beispielkonfiguration vorbereitet |
 | Installer | offen | Installer muss weiter auf echte Endanwender Robustheit geprüft werden |
 | Backend Integration | offen | LifeOS liest noch keine echten Daten aus Backend oder lokaler Runtime |
 | Tests und CI | vorhanden | CI ist angelegt, muss bei größeren Dependency Updates aufmerksam geprüft werden |
 
 ## Erledigte Updates
+
+### B6.7.0
+
+- Daily Command Center Datenfelder in `config/lifeos.example.json` ergänzt.
+- `daily_briefing.day_focus` für den Tagesfokus ergänzt.
+- `daily_briefing.top_tasks` für Top 3 Aufgaben mit Bereich, Wirkung, Aufwand und nächstem Schritt ergänzt.
+- Dokumentation `docs/lifeos-daily-command-center.md` ergänzt.
+- Changelog und PROJECT_STATUS gemäß Pflege Regel aktualisiert.
 
 ### B6.6.6
 
@@ -108,7 +117,7 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 
 | Priorität | Thema | Status | Nächster Schritt |
 |---|---|---|---|
-| Hoch | Daily Command Center | offen | Top 3 Aufgaben, Tagesfokus und klaren nächsten Schritt aus lokalen Daten ableiten |
+| Hoch | Daily Command Center UI | offen | Tagesfokus und Top 3 Aufgaben im LifeOS Command Center anzeigen |
 | Hoch | Work Radar 2.0 | offen | strukturierte Vorgänge für SAP, FSM, LNW, Mail, Angebote und Rückfragen ergänzen |
 | Hoch | Installer Prüfung | offen | Start, First Setup, Python Erkennung und PowerShell ExecutionPolicy erneut testen |
 | Mittel | Learning Coach | offen | Lernstände, Wiederholungen und Schwachstellen lokal abbilden |
@@ -131,6 +140,7 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 | `docs/lifeos-roadmap.md` | Ausgearbeitete LifeOS Upgrade Roadmap mit Modulen, Nutzen, Umsetzung und Akzeptanzkriterien |
 | `docs/lifeos-global-upgrade.md` | Grundkonzept des LifeOS Global Upgrade |
 | `docs/lifeos-private-config.md` | Anleitung für die private lokale LifeOS Konfiguration |
+| `docs/lifeos-daily-command-center.md` | Datenmodell und Akzeptanzkriterien für Tagesfokus und Top 3 Aufgaben |
 | `CHANGELOG.md` | Versionierte Änderungen |
 | `PROJECT_STATUS.md` | Projektstand, offene Todos, Risiken und nächster sinnvoller Schritt |
 
@@ -146,12 +156,12 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 
 ## Nächster sinnvoller Schritt
 
-Nach der persönlichen LifeOS Vorlage ist der nächste sinnvolle Schritt das Daily Command Center. Dafür soll LifeOS aus lokalen Daten Top 3 Aufgaben, Tagesfokus und einen klaren nächsten Schritt ableiten.
+Nach dem Daily Command Center Datenmodell ist der nächste sinnvolle Schritt die UI Anzeige im LifeOS Command Center. Dafür sollen Tagesfokus und Top 3 Aufgaben sichtbar gerendert und in die generierte Tageslage einbezogen werden.
 
 Empfohlene Reihenfolge:
 
 ```text
-1. Daily Command Center um Top 3 Aufgaben erweitern
+1. Daily Command Center UI um Tagesfokus und Top 3 Aufgaben erweitern
 2. Work Radar 2.0 Schema ergänzen
 3. Installer Robustheit erneut prüfen
 4. Backend Health Check sauber anbinden

--- a/config/lifeos.example.json
+++ b/config/lifeos.example.json
@@ -1,12 +1,36 @@
 {
-  "version": "B6.6.1",
+  "version": "B6.7.0",
   "mode": "local-first",
   "daily_briefing": {
     "day_mode": "FOCUSED",
+    "day_focus": "Offene Arbeitsthemen mit Außenwirkung zuerst schließen",
     "priority_count": 3,
     "focus_minutes": 92,
     "open_loops": 7,
     "energy_percent": 81,
+    "top_tasks": [
+      {
+        "title": "Offene Rückfragen prüfen",
+        "area": "work",
+        "impact": "high",
+        "effort": "medium",
+        "next_step": "Rückfragen mit Kunden oder Kollegen sortieren und beantworten"
+      },
+      {
+        "title": "LNW und FSM Buchungen kontrollieren",
+        "area": "work",
+        "impact": "high",
+        "effort": "medium",
+        "next_step": "Fehlende Nachweise und Buchungsabweichungen prüfen"
+      },
+      {
+        "title": "Lernblock oder Projektblock reservieren",
+        "area": "learn",
+        "impact": "medium",
+        "effort": "low",
+        "next_step": "Fokusfenster am Nachmittag blocken"
+      }
+    ],
     "today_important": [
       "Offene Rückfragen aus Arbeit und Abrechnung prüfen",
       "LNW und FSM Buchungen auf fehlende Nachweise kontrollieren",

--- a/docs/lifeos-daily-command-center.md
+++ b/docs/lifeos-daily-command-center.md
@@ -1,0 +1,82 @@
+# LifeOS Daily Command Center
+
+Das Daily Command Center ist die nächste Ausbaustufe nach dem einfachen Daily Briefing. Es soll nicht nur Werte anzeigen, sondern den Tag praktisch sortieren.
+
+## Ziel
+
+LifeOS soll aus lokalen Daten ableiten:
+
+```text
+Tagesfokus
+Top 3 Aufgaben
+offene Schleifen
+Energie Einschätzung
+Fokuszeit
+nächster sinnvoller Schritt
+```
+
+## Neue Datenfelder
+
+Die Beispielkonfiguration `config/lifeos.example.json` wurde um diese Felder erweitert:
+
+```text
+daily_briefing.day_focus
+daily_briefing.top_tasks[]
+```
+
+## Top Task Struktur
+
+Jede Top Aufgabe enthält:
+
+```text
+title
+area
+impact
+effort
+next_step
+```
+
+Beispiel:
+
+```json
+{
+  "title": "Offene Rückfragen prüfen",
+  "area": "work",
+  "impact": "high",
+  "effort": "medium",
+  "next_step": "Rückfragen mit Kunden oder Kollegen sortieren und beantworten"
+}
+```
+
+## Bewertungslogik
+
+Die spätere Logik soll Aufgaben nicht nur anzeigen, sondern gewichten.
+
+Geplante Kriterien:
+
+| Kriterium | Bedeutung |
+|---|---|
+| impact | Wirkung nach außen oder Risiko bei Nichtbearbeitung |
+| effort | geschätzter Aufwand |
+| area | work, learn, health, private oder project |
+| next_step | konkrete nächste Handlung |
+
+## Erste Akzeptanzkriterien
+
+```text
+[ ] LifeOS zeigt einen Tagesfokus
+[ ] LifeOS zeigt maximal 3 wichtigste Aufgaben
+[ ] jede Aufgabe hat einen konkreten nächsten Schritt
+[ ] Daily Briefing Generator kann Top Tasks in die Tageslage einbeziehen
+[ ] private Werte bleiben in config/lifeos.json
+```
+
+## Nächster technischer Schritt
+
+Die LifeOS UI soll die neuen Felder sichtbar machen:
+
+```text
+1. Tagesfokus prominent im Daily Briefing anzeigen
+2. Top 3 Aufgaben als eigene Liste rendern
+3. Generated Daily Briefing um Top Task Bezug erweitern
+```


### PR DESCRIPTION
## Beschreibung

Ergänzt das Datenmodell für das LifeOS Daily Command Center.

## Änderungen

- `config/lifeos.example.json` auf `B6.7.0` aktualisiert
- neues Feld `daily_briefing.day_focus`
- neues Array `daily_briefing.top_tasks`
- Top Tasks enthalten Titel, Bereich, Wirkung, Aufwand und nächsten Schritt
- neue Dokumentation `docs/lifeos-daily-command-center.md`
- CHANGELOG.md Eintrag `B6.7.0`
- PROJECT_STATUS.md gemäß Pflege Regel aktualisiert

## Ziel

LifeOS ist damit auf Tagesfokus und Top 3 Aufgaben vorbereitet. Der nächste Schritt ist die UI Anzeige im LifeOS Command Center.

## Sicherheit

- nur Beispielwerte
- keine privaten Daten
- keine Secrets
- keine Kundendaten