### PR TITLE
docs: sync LifeOS roadmap with B6.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ Alle nennenswerten Änderungen an diesem Projekt werden in dieser Datei dokument
 
 Das Format orientiert sich an Keep a Changelog. Versionen folgen dem Projektstand B1 bis B6 und den Build Versionen von JARVIS.
 
+## [B6.6.8] - 2026-05-01
+
+### Changed
+
+- PROJECT_STATUS.md auf den tatsächlichen B6.6.7 Stand synchronisiert.
+- LifeOS Roadmap Status von pauschal geplant auf erledigt, in Arbeit und geplant aktualisiert.
+- Offene Todos nach den neuen LifeOS Backend, Work Radar und Installer Updates neu sortiert.
+- PR 30 als zu prüfender, vermutlich teilweise überholter Punkt aufgenommen.
+
+### Fixed
+
+- Abweichung zwischen CHANGELOG.md, PROJECT_STATUS.md und docs/lifeos-roadmap.md korrigiert.
+
+## [B6.6.7] - 2026-05-01
+
+### Added
+
+- LifeOS Daily Command Center als eigenes JARVIS Sidebar Panel integriert.
+- Neue Backend API fuer LifeOS Status, Briefing, Regeneration und Installer Check ergaenzt.
+- Work Radar 2.0 Struktur mit sortierbaren Vorgaengen, Risiko, Status, Frist und naechstem Schritt vorbereitet.
+- Tests fuer LifeOS Briefing, Work Radar und Installer Robustheit ergaenzt.
+
+### Changed
+
+- `config/lifeos.example.json` um `daily_briefing.summary` und strukturierte `work_radar.items` erweitert.
+- `FIRST_SETUP.ps1` bereitet die private lokale LifeOS Konfiguration vor, ohne bestehende private Daten zu ueberschreiben.
+
+### Security
+
+- Private LifeOS Daten bleiben weiter in `config/lifeos.json` und werden nicht committed.
+- Installer Check prueft, ob private Config ignoriert und Setup ohne `-Force` ausgefuehrt wird.
+
 ## [B6.6.6] - 2026-05-01
 
 ### Added

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -34,15 +34,27 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 | ULTRON Grid | erledigt | JARVIS und ULTRON Command Grid mit Modus Umschaltung vorhanden |
 | LifeOS Command Center | erledigt | Erste sichtbare LifeOS Oberfläche vorhanden |
 | LifeOS lokale Daten | erledigt | Beispielkonfiguration vorhanden und LifeOS kann lokale JSON Werte laden |
-| LifeOS Daily Briefing | erledigt | LifeOS erzeugt eine erste Tageslage aus Prioritäten, offenen Schleifen, Energie, Fokuszeit und Work Radar |
 | LifeOS private Config | erledigt | `config/lifeos.json` wird bevorzugt geladen und über `.gitignore` aus dem Repository gehalten |
-| LifeOS Roadmap | erledigt | Ausgearbeitete Upgrade Roadmap liegt unter `docs/lifeos-roadmap.md` |
 | LifeOS persönliche Vorlage | erledigt | Skript und Anleitung zum Erzeugen der privaten `config/lifeos.json` vorhanden |
-| Installer | offen | Installer muss weiter auf echte Endanwender Robustheit geprüft werden |
-| Backend Integration | offen | LifeOS liest noch keine echten Daten aus Backend oder lokaler Runtime |
-| Tests und CI | vorhanden | CI ist angelegt, muss bei größeren Dependency Updates aufmerksam geprüft werden |
+| LifeOS Roadmap | erledigt | Ausgearbeitete Upgrade Roadmap liegt unter `docs/lifeos-roadmap.md` |
+| LifeOS Daily Command Center | in Arbeit | Eigenes JARVIS Sidebar Panel, Status API, Briefing API und Regeneration sind vorhanden. Top 3 Aufgaben und UI Feinschliff bleiben offen |
+| LifeOS Daily Briefing | erledigt | LifeOS erzeugt eine erste Tageslage aus Prioritäten, offenen Schleifen, Energie, Fokuszeit und Work Radar |
+| Work Radar 2.0 | in Arbeit | Strukturierte Vorgänge mit Status, Risiko, Frist, Score und nächstem Schritt sind vorbereitet. UI Sortierung und echte Quellen fehlen noch |
+| Backend Integration | in Arbeit | LifeOS API für Status, Briefing, Regeneration und Installer Check ist vorhanden. Echte Runtime Daten und weitere Module fehlen noch |
+| Installer | in Arbeit | FIRST_SETUP bereitet private LifeOS Konfiguration vor. Robustheitstests sind ergänzt, echter Endanwender Test bleibt offen |
+| Tests und CI | in Arbeit | Tests für LifeOS Briefing, Work Radar und Installer Robustheit sind ergänzt. CI und Dependabot müssen weiter beobachtet werden |
 
 ## Erledigte Updates
+
+### B6.6.7
+
+- LifeOS Daily Command Center als eigenes JARVIS Sidebar Panel integriert.
+- Backend API für LifeOS Status, Briefing, Regeneration und Installer Check ergänzt.
+- Work Radar 2.0 Struktur mit sortierbaren Vorgängen, Risiko, Status, Frist und nächstem Schritt vorbereitet.
+- Tests für LifeOS Briefing, Work Radar und Installer Robustheit ergänzt.
+- `config/lifeos.example.json` um `daily_briefing.summary` und strukturierte `work_radar.items` erweitert.
+- `FIRST_SETUP.ps1` bereitet die private lokale LifeOS Konfiguration vor, ohne bestehende private Daten zu überschreiben.
+- Changelog war bereits aktualisiert. PROJECT_STATUS wird mit diesem Update auf denselben Stand gebracht.
 
 ### B6.6.6
 
@@ -108,20 +120,20 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 
 | Priorität | Thema | Status | Nächster Schritt |
 |---|---|---|---|
-| Hoch | Daily Command Center | offen | Top 3 Aufgaben, Tagesfokus und klaren nächsten Schritt aus lokalen Daten ableiten |
-| Hoch | Work Radar 2.0 | offen | strukturierte Vorgänge für SAP, FSM, LNW, Mail, Angebote und Rückfragen ergänzen |
-| Hoch | Installer Prüfung | offen | Start, First Setup, Python Erkennung und PowerShell ExecutionPolicy erneut testen |
+| Hoch | Daily Command Center UI Feinschliff | offen | Top 3 Aufgaben, Tagesfokus und klaren nächsten Schritt im Sidebar Panel sauber sichtbar machen |
+| Hoch | Work Radar 2.0 UI Sortierung | offen | Vorgänge nach Risiko, Frist und Status sortieren und kritische Punkte hervorheben |
+| Hoch | Installer Endanwender Test | offen | Start, First Setup, Python Erkennung und PowerShell ExecutionPolicy auf frischem Windows testen |
+| Hoch | PR 30 prüfen | offen | PR 30 ist durch B6.6.7 teilweise überholt. Inhalt prüfen, relevante Teile übernehmen oder PR schließen |
+| Mittel | Backend Runtime Daten | offen | LifeOS API mit echten lokalen Runtime Daten statt nur Beispiel oder Statusdaten versorgen |
 | Mittel | Learning Coach | offen | Lernstände, Wiederholungen und Schwachstellen lokal abbilden |
 | Mittel | Decision Assistant | offen | Optionen, Aufwand, Risiko, Nutzen und Empfehlung als Schema ergänzen |
 | Mittel | Private Project Manager | offen | private Projekte mit Status, Blocker und nächstem Schritt führen |
 | Mittel | Health und Energy Radar | offen | Energie, Belastung, Pausen und Fokusfenster in die Planung aufnehmen |
 | Mittel | Finance und Contract Radar | offen | Verträge, Rechnungen, Abos, Fristen und Nachweise lokal strukturieren |
 | Mittel | Memory und Knowledge Layer | offen | Regeln, Notizen, Dokumente, Entscheidungen und Quellen lokal verwalten |
-| Mittel | Backend Health Check | offen | lokalen `/health` Check sauber mit Frontend und Installer verbinden |
 | Mittel | DiagCenter | offen | Diagnose Modul für Python, Node, Ports, Config und Logs konkretisieren |
 | Niedrig | Voice und Push to Talk | offen | Mikrofon default off, lokale TTS und bewusste Aktivierung planen |
 | Niedrig | Automation Layer | offen | lokale Automationen mit RiskLevel, Freigabe und Audit Log vorbereiten |
-| Niedrig | UI Feinschliff LifeOS | offen | Layout, Texte und Live Werte nach erstem lokalen Test nachschärfen |
 | Niedrig | Release ZIP | offen | GitHub Release Workflow mit echtem Tag testen |
 
 ## Roadmap Dokumente
@@ -138,24 +150,25 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 
 | Risiko | Einschätzung | Empfehlung |
 |---|---|---|
-| Browser blockiert lokale JSON Datei | mittel | LifeOS über lokalen Server starten oder später Backend API nutzen |
+| PR 30 basiert auf älterem Stand | hoch | nicht blind mergen, sondern gegen B6.6.7 prüfen |
+| Browser blockiert lokale JSON Datei | mittel | LifeOS über lokalen Server starten oder Backend API nutzen |
 | Dependabot Major Updates | hoch | React, TypeScript, Vite und Actions Major Updates nicht blind mergen |
 | Installer Fehler bei Endanwendern | hoch | Installer weiterhin als eigener Schwerpunkt behandeln |
 | Private Daten im Repo | reduziert | `config/lifeos.json` ist ignoriert, trotzdem vor Commits prüfen |
-| Roadmap wird zu groß ohne Umsetzung | mittel | pro PR nur ein klarer Roadmap Punkt umsetzen |
+| Roadmap wird zu groß ohne Umsetzung | mittel | pro PR nur einen klaren Roadmap Punkt umsetzen |
 
 ## Nächster sinnvoller Schritt
 
-Nach der persönlichen LifeOS Vorlage ist der nächste sinnvolle Schritt das Daily Command Center. Dafür soll LifeOS aus lokalen Daten Top 3 Aufgaben, Tagesfokus und einen klaren nächsten Schritt ableiten.
+Nach B6.6.7 ist der nächste sinnvolle Schritt nicht mehr das Grundmodell, sondern der Abgleich von PR 30 und danach der UI Feinschliff für das Daily Command Center.
 
 Empfohlene Reihenfolge:
 
 ```text
-1. Daily Command Center um Top 3 Aufgaben erweitern
-2. Work Radar 2.0 Schema ergänzen
-3. Installer Robustheit erneut prüfen
-4. Backend Health Check sauber anbinden
-5. DiagCenter konkretisieren
+1. PR 30 prüfen und entweder relevante Teile übernehmen oder schließen
+2. Daily Command Center UI Feinschliff für Top 3 Aufgaben und Tagesfokus umsetzen
+3. Work Radar 2.0 UI Sortierung ergänzen
+4. Installer Endanwender Test auf frischem Windows durchführen
+5. Backend Runtime Daten konkret anbinden
 ```
 
 ## Pflege Ablauf

--- a/docs/lifeos-roadmap.md
+++ b/docs/lifeos-roadmap.md
@@ -6,13 +6,17 @@ Diese Roadmap beschreibt die größeren LifeOS Upgrade Ideen als konkrete Ausbau
 
 LifeOS bleibt Local First. Private Daten gehören in lokale Dateien wie `config/lifeos.json` und nicht ins Repository.
 
-## Übersicht
+## Aktueller Roadmap Stand
+
+Stand: B6.6.7
 
 | Priorität | Modul | Ziel | Status |
 |---|---|---|---|
-| Hoch | Daily Command Center | Tageslage, Fokus und nächster Schritt | geplant |
-| Hoch | Work Radar 2.0 | SAP, FSM, LNW, Mail, Angebote und Rückfragen strukturieren | geplant |
-| Hoch | LifeOS persönliche Vorlage | lokale `config/lifeos.json` einfacher erzeugen | geplant |
+| Hoch | Daily Command Center | Tageslage, Fokus und nächster Schritt | in Arbeit |
+| Hoch | Work Radar 2.0 | SAP, FSM, LNW, Mail, Angebote und Rückfragen strukturieren | in Arbeit |
+| Hoch | LifeOS persönliche Vorlage | lokale `config/lifeos.json` einfacher erzeugen | erledigt |
+| Hoch | Installer Robustheit | Setup, First Setup, Python Erkennung und ExecutionPolicy absichern | in Arbeit |
+| Mittel | Backend Runtime Daten | LifeOS API mit echten lokalen Runtime Daten versorgen | in Arbeit |
 | Mittel | Learning Coach | Meister, AEVO und Lernstände aktiv verfolgen | geplant |
 | Mittel | Decision Assistant | Optionen, Risiken und Empfehlung strukturiert bewerten | geplant |
 | Mittel | Private Project Manager | private Projekte mit Status und nächstem Schritt führen | geplant |
@@ -24,7 +28,26 @@ LifeOS bleibt Local First. Private Daten gehören in lokale Dateien wie `config/
 
 ## 1. Daily Command Center
 
-Ziel: JARVIS soll morgens eine klare Lage liefern und nicht nur Werte anzeigen.
+Status: in Arbeit
+
+Bereits erledigt:
+
+```text
+LifeOS Daily Command Center als JARVIS Sidebar Panel integriert
+LifeOS Status API ergänzt
+Briefing API ergänzt
+Regeneration API ergänzt
+erste Tageslage über Backend vorbereitet
+```
+
+Noch offen:
+
+```text
+Top 3 Aufgaben prominent anzeigen
+Tagesfokus klar sichtbar machen
+nächsten sinnvollen Schritt besser aus lokalen Daten ableiten
+Gewichtung nach Dringlichkeit, Außenwirkung und Aufwand einführen
+```
 
 Nutzen:
 
@@ -33,38 +56,42 @@ Nutzen:
 - weniger gedankliches Sortieren am Morgen
 - klare nächste Aktion statt langer Aufgabenliste
 
-Geplante Inhalte:
-
-```text
-Tagesfokus
-offene Schleifen
-wichtige Arbeitsthemen
-private Fristen
-Lernblock
-Energie Einschätzung
-nächster sinnvoller Schritt
-```
-
 Nächste Umsetzung:
 
 ```text
-1. daily_briefing.summary in config/lifeos.example.json erweitern
-2. LifeOS UI um Tagesfokus und Top 3 Aufgaben ergänzen
-3. Gewichtung nach Dringlichkeit, Außenwirkung und Aufwand einführen
+1. PR 30 prüfen und verwertbare Teile übernehmen oder schließen
+2. Tagesfokus und Top 3 Aufgaben in der UI sauber sichtbar machen
+3. Briefing Generator stärker an Aufgaben, Risiko und Fristen koppeln
 ```
 
 Akzeptanzkriterien:
 
 ```text
-[ ] LifeOS zeigt eine Tageslage in natürlicher Sprache
-[ ] LifeOS zeigt maximal 3 wichtigste Aufgaben
-[ ] LifeOS zeigt einen nächsten sinnvollen Schritt
-[ ] Werte kommen aus lokaler JSON oder später Backend API
+[x] LifeOS zeigt eine Tageslage in natürlicher Sprache
+[ ] LifeOS zeigt maximal 3 wichtigste Aufgaben sichtbar im UI
+[ ] LifeOS zeigt einen nächsten sinnvollen Schritt aus echten lokalen Daten
+[ ] Werte kommen aus lokaler JSON oder Backend API
 ```
 
 ## 2. Work Radar 2.0
 
-Ziel: Arbeitsthemen sollen nicht nur als Notizen existieren, sondern als strukturierte offene Vorgänge.
+Status: in Arbeit
+
+Bereits erledigt:
+
+```text
+work_radar.items Struktur vorbereitet
+Vorgänge haben Status, Risiko, Frist, Score und nächsten Schritt
+Tests für Work Radar ergänzt
+```
+
+Noch offen:
+
+```text
+UI Sortierung nach Risiko, Frist und Status
+kritische Vorgänge visuell hervorheben
+echte lokale Quellen später anbinden
+```
 
 Nutzen:
 
@@ -89,20 +116,105 @@ Abrechnung Risiken
 Nächste Umsetzung:
 
 ```text
-1. work_radar.items Array in LifeOS Config ergänzen
-2. Statuswerte definieren: open, waiting, blocked, done, attention
-3. UI nach Risiko und Dringlichkeit sortieren lassen
+1. Work Radar UI nach Risiko sortieren
+2. Statuswerte vereinheitlichen: open, waiting, blocked, done, attention
+3. echte lokale Datenquellen später anbinden
 ```
 
 Akzeptanzkriterien:
 
 ```text
-[ ] Work Radar kann mehrere Vorgänge anzeigen
-[ ] jeder Vorgang hat Status, Risiko, nächsten Schritt und Frist
+[x] Work Radar kann mehrere Vorgänge anzeigen oder verarbeiten
+[x] jeder Vorgang hat Status, Risiko, nächsten Schritt und Frist
 [ ] kritische Vorgänge werden sichtbar hervorgehoben
+[ ] UI sortiert Vorgänge nach Dringlichkeit
 ```
 
-## 3. Learning Coach
+## 3. LifeOS persönliche Vorlage
+
+Status: erledigt
+
+Erledigt:
+
+```text
+setup-lifeos-config.ps1 ergänzt
+lifeos-private-config.md ergänzt
+FIRST_SETUP.ps1 bereitet private lokale LifeOS Konfiguration vor
+config/lifeos.json bleibt lokal und wird nicht committed
+bestehende private Daten werden nicht überschrieben
+```
+
+Akzeptanzkriterien:
+
+```text
+[x] private config/lifeos.json kann aus Beispiel erzeugt werden
+[x] bestehende config/lifeos.json wird nicht ohne Force überschrieben
+[x] private Datei ist ignoriert
+[x] Dokumentation vorhanden
+```
+
+## 4. Installer Robustheit
+
+Status: in Arbeit
+
+Bereits erledigt:
+
+```text
+FIRST_SETUP.ps1 bereitet LifeOS private Config vor
+Tests für Installer Robustheit ergänzt
+```
+
+Noch offen:
+
+```text
+frisches Windows Testszenario prüfen
+Python Erkennung real testen
+PowerShell ExecutionPolicy real testen
+Start und First Setup Endanwender Ablauf prüfen
+```
+
+Akzeptanzkriterien:
+
+```text
+[ ] frisches Windows System kann Setup starten
+[ ] ExecutionPolicy blockiert nicht
+[ ] Python wird sauber erkannt oder verständlich gemeldet
+[ ] START_JARVIS.bat startet ohne manuelle Nacharbeit
+```
+
+## 5. Backend Runtime Daten
+
+Status: in Arbeit
+
+Bereits erledigt:
+
+```text
+Backend API für LifeOS Status ergänzt
+Backend API für LifeOS Briefing ergänzt
+Backend API für Regeneration ergänzt
+Backend API für Installer Check ergänzt
+```
+
+Noch offen:
+
+```text
+echte lokale Runtime Daten anbinden
+Health Check sauber mit Frontend und Installer verbinden
+DiagCenter vorbereiten
+```
+
+Akzeptanzkriterien:
+
+```text
+[x] LifeOS Backend API existiert
+[ ] API liefert echte lokale Runtime Daten
+[ ] Frontend zeigt API Health eindeutig an
+[ ] Installer kann API Status prüfen
+```
+
+## 6. Learning Coach
+
+Status: geplant
 
 Ziel: JARVIS soll Lernstände für Meister, AEVO und spätere Themen aktiv verfolgen.
 
@@ -141,7 +253,9 @@ Akzeptanzkriterien:
 [ ] Wiederholungstermine können lokal gespeichert werden
 ```
 
-## 4. Health und Energy Radar
+## 7. Health und Energy Radar
+
+Status: geplant
 
 Ziel: JARVIS soll Energie, Belastung und Pausen als Planungshilfe berücksichtigen, ohne medizinische Bewertung zu spielen.
 
@@ -179,7 +293,9 @@ Akzeptanzkriterien:
 [ ] Daten bleiben vollständig lokal
 ```
 
-## 5. Finance und Contract Radar
+## 8. Finance und Contract Radar
+
+Status: geplant
 
 Ziel: Verträge, Rechnungen, Fristen, Abos und steuerlich relevante Themen sollen lokal sichtbar werden.
 
@@ -218,7 +334,9 @@ Akzeptanzkriterien:
 [ ] keine Finanzdaten werden ins Repository committed
 ```
 
-## 6. Private Project Manager
+## 9. Private Project Manager
+
+Status: geplant
 
 Ziel: JARVIS soll private Projekte und technische Bastelthemen strukturiert verwalten.
 
@@ -257,7 +375,9 @@ Akzeptanzkriterien:
 [ ] blockierte Projekte werden sichtbar markiert
 ```
 
-## 7. Decision Assistant
+## 10. Decision Assistant
+
+Status: geplant
 
 Ziel: JARVIS soll Entscheidungen strukturieren, Optionen vergleichen und einen begründeten nächsten Schritt vorschlagen.
 
@@ -296,7 +416,9 @@ Akzeptanzkriterien:
 [ ] JARVIS zeigt keine Scheinsicherheit, sondern begründet knapp
 ```
 
-## 8. Memory und Knowledge Layer
+## 11. Memory und Knowledge Layer
+
+Status: geplant
 
 Ziel: Wiederkehrende Regeln, Projektwissen, Notizen und lokale Dokumente sollen als Wissensbasis nutzbar werden.
 
@@ -336,7 +458,9 @@ Akzeptanzkriterien:
 [ ] private Inhalte werden nicht automatisch committed
 ```
 
-## 9. Voice und Push to Talk
+## 12. Voice und Push to Talk
+
+Status: geplant
 
 Ziel: JARVIS soll später per Sprache nutzbar sein, aber nur bewusst und kontrolliert.
 
@@ -373,7 +497,9 @@ Akzeptanzkriterien:
 [ ] kritische Aktionen werden nicht automatisch ausgeführt
 ```
 
-## 10. Automation Layer
+## 13. Automation Layer
+
+Status: geplant
 
 Ziel: kleine lokale Automationen sollen Aufgaben vorbereiten, aber nicht blind handeln.
 
@@ -412,19 +538,20 @@ Akzeptanzkriterien:
 [ ] jede Ausführung wird lokal protokolliert
 ```
 
-## Empfohlene Reihenfolge
+## Empfohlene Reihenfolge ab B6.6.7
 
 ```text
-1. LifeOS persönliche Vorlage erstellen
-2. Daily Command Center erweitern
-3. Work Radar 2.0 strukturieren
-4. Installer Robustheit prüfen
-5. Learning Coach ergänzen
-6. Decision Assistant ergänzen
-7. Private Project Manager ergänzen
-8. Health und Energy Radar ergänzen
-9. Finance und Contract Radar ergänzen
-10. Memory und Knowledge Layer konkretisieren
-11. Voice und Push to Talk planen
-12. Automation Layer mit Audit Log vorbereiten
+1. PR 30 prüfen und verwertbare Teile übernehmen oder schließen
+2. Daily Command Center UI Feinschliff umsetzen
+3. Work Radar 2.0 UI Sortierung ergänzen
+4. Installer Endanwender Test durchführen
+5. Backend Runtime Daten anbinden
+6. Learning Coach ergänzen
+7. Decision Assistant ergänzen
+8. Private Project Manager ergänzen
+9. Health und Energy Radar ergänzen
+10. Finance und Contract Radar ergänzen
+11. Memory und Knowledge Layer konkretisieren
+12. Voice und Push to Talk planen
+13. Automation Layer mit Audit Log vorbereiten
 ```


### PR DESCRIPTION
## Beschreibung

Synchronisiert PROJECT_STATUS.md und docs/lifeos-roadmap.md mit dem aktuellen Stand aus B6.6.7.

## Änderungen

- PROJECT_STATUS.md auf B6.6.7 Stand gebracht
- LifeOS Roadmap Status aktualisiert
- Daily Command Center von offen auf in Arbeit gesetzt
- Work Radar 2.0 von offen auf in Arbeit gesetzt
- Backend Integration von offen auf in Arbeit gesetzt
- Installer von offen auf in Arbeit gesetzt
- Tests und CI von vorhanden auf in Arbeit präzisiert
- PR 30 als zu prüfender Punkt aufgenommen
- CHANGELOG.md Eintrag B6.6.8 ergänzt

## Warum

Nach den neuen Pushes waren CHANGELOG.md, PROJECT_STATUS.md und docs/lifeos-roadmap.md nicht mehr synchron. Das wird mit diesem PR korrigiert.

## Nächster Schritt

PR 30 prüfen. Der PR basiert auf einem älteren Stand und ist durch B6.6.7 teilweise überholt. Relevante Teile übernehmen oder PR schließen.