### PR TITLE
fix: harden JARVIS sound unlock handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ Alle nennenswerten Änderungen an diesem Projekt werden in dieser Datei dokument
 
 Das Format orientiert sich an Keep a Changelog. Versionen folgen dem Projektstand B1 bis B6 und den Build Versionen von JARVIS.
 
+## [B6.6.13] - 2026-05-01
+
+### Fixed
+
+- Sound Engine respektiert Browser Autoplay Regeln jetzt strenger und spielt erst nach erfolgreichem Audio Unlock.
+- Reload Problem entschärft, bei dem Sound zwar im HUD als aktiviert gespeichert war, der Browser AudioContext aber noch gesperrt blieb.
+- WebKit Fallback für `webkitAudioContext` ergänzt.
+
+### Changed
+
+- Sound Events werden ignoriert, solange der AudioContext nicht wirklich freigeschaltet ist, statt stumm in einen gesperrten Context zu laufen.
+
 ## [B6.6.12] - 2026-05-01
 
 ### Added

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -38,12 +38,19 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 | LifeOS private Config | erledigt | `config/lifeos.json` wird bevorzugt geladen und über `.gitignore` aus dem Repository gehalten |
 | LifeOS Roadmap | erledigt | Ausgearbeitete Upgrade Roadmap liegt unter `docs/lifeos-roadmap.md` |
 | LifeOS persönliche Vorlage | erledigt | Skript und Anleitung zum Erzeugen der privaten `config/lifeos.json` vorhanden |
-| JARVIS Sound Layer | erledigt | Lokaler Web Audio Sound Layer mit Toggle und Lautstaerke im HUD vorhanden |
+| JARVIS Sound Layer | in Arbeit | Lokaler Web Audio Sound Layer vorhanden. Unlock Verhalten wurde robuster gemacht, Frontend Re Unlock nach Reload bleibt als Feinschliff offen |
 | Installer | offen | Installer muss weiter auf echte Endanwender Robustheit geprüft werden |
 | Backend Integration | offen | LifeOS liest noch keine echten Daten aus Backend oder lokaler Runtime |
 | Tests und CI | vorhanden | CI ist angelegt, muss bei größeren Dependency Updates aufmerksam geprüft werden |
 
 ## Erledigte Updates
+
+### B6.6.13
+
+- Sound Engine prüft jetzt, ob der AudioContext wirklich freigeschaltet ist, bevor Events abgespielt werden.
+- Reload Problem entschärft, bei dem Sound im HUD als aktiviert gespeichert war, der Browser AudioContext aber noch gesperrt blieb.
+- WebKit Fallback für `webkitAudioContext` ergänzt.
+- Changelog und PROJECT_STATUS gemäß Pflege Regel aktualisiert.
 
 ### B6.6.12
 
@@ -123,20 +130,17 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 
 | Priorität | Thema | Status | Nächster Schritt |
 |---|---|---|---|
-| Hoch | Daily Command Center | offen | Top 3 Aufgaben, Tagesfokus und klaren nächsten Schritt aus lokalen Daten ableiten |
-| Hoch | Work Radar 2.0 | erledigt | Kategorien, Status, Risiko, Fristlage und naechste Work Aktion werden aus lokalen Daten abgeleitet |
+| Hoch | Sound Re Unlock im Frontend | offen | Wenn Sound gespeichert aktiv ist, beim nächsten Nutzerklick AudioContext erneut unlocken und Status klar anzeigen |
 | Hoch | Installer Prüfung | offen | Start, First Setup, Python Erkennung und PowerShell ExecutionPolicy erneut testen |
-| Mittel | Learning Coach | offen | Lernstände, Wiederholungen und Schwachstellen lokal abbilden |
+| Mittel | Backend Health Check | offen | lokalen `/health` Check sauber mit Frontend und Installer verbinden |
+| Mittel | DiagCenter | offen | Diagnose Modul für Python, Node, Ports, Config und Logs konkretisieren |
 | Mittel | Decision Assistant | offen | Optionen, Aufwand, Risiko, Nutzen und Empfehlung als Schema ergänzen |
 | Mittel | Private Project Manager | offen | private Projekte mit Status, Blocker und nächstem Schritt führen |
 | Mittel | Health und Energy Radar | offen | Energie, Belastung, Pausen und Fokusfenster in die Planung aufnehmen |
 | Mittel | Finance und Contract Radar | offen | Verträge, Rechnungen, Abos, Fristen und Nachweise lokal strukturieren |
 | Mittel | Memory und Knowledge Layer | offen | Regeln, Notizen, Dokumente, Entscheidungen und Quellen lokal verwalten |
-| Mittel | Backend Health Check | offen | lokalen `/health` Check sauber mit Frontend und Installer verbinden |
-| Mittel | DiagCenter | offen | Diagnose Modul für Python, Node, Ports, Config und Logs konkretisieren |
 | Niedrig | Voice und Push to Talk | offen | Mikrofon default off, lokale TTS und bewusste Aktivierung planen |
 | Niedrig | Automation Layer | offen | lokale Automationen mit RiskLevel, Freigabe und Audit Log vorbereiten |
-| Niedrig | UI Feinschliff LifeOS | offen | Layout, Texte und Live Werte nach erstem lokalen Test nachschärfen |
 | Niedrig | Release ZIP | offen | GitHub Release Workflow mit echtem Tag testen |
 
 ## Roadmap Dokumente
@@ -153,7 +157,7 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 
 | Risiko | Einschätzung | Empfehlung |
 |---|---|---|
-| Browser blockiert lokale JSON Datei | mittel | LifeOS über lokalen Server starten oder später Backend API nutzen |
+| Browser Autoplay blockiert Sound nach Reload | hoch | Sound braucht nach Reload eine bewusste Nutzeraktion oder einen klaren Re Unlock Ablauf |
 | Dependabot Major Updates | hoch | React, TypeScript, Vite und Actions Major Updates nicht blind mergen |
 | Installer Fehler bei Endanwendern | hoch | Installer weiterhin als eigener Schwerpunkt behandeln |
 | Private Daten im Repo | reduziert | `config/lifeos.json` ist ignoriert, trotzdem vor Commits prüfen |
@@ -161,16 +165,16 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 
 ## Nächster sinnvoller Schritt
 
-Nach Daily Command Center, Learning Coach und Work Radar 2.0 ist der nächste sinnvolle Schritt die Installer Robustheit. Dafür sollen Start, First Setup, Python Erkennung und PowerShell ExecutionPolicy erneut geprüft werden.
+Nach dem Sound Engine Fix ist der nächste sinnvolle Schritt der kleine Frontend Feinschliff: Wenn Sound gespeichert aktiv ist, soll der nächste Nutzerklick den AudioContext wieder freischalten und der HUD Status soll nicht irreführend wirken.
 
 Empfohlene Reihenfolge:
 
 ```text
-1. Installer Robustheit erneut prüfen
-2. Backend Health Check sauber anbinden
-3. DiagCenter konkretisieren
-4. Decision Assistant ergänzen
-5. Private Project Manager ergänzen
+1. Sound Re Unlock im Frontend ergänzen
+2. Installer Robustheit erneut prüfen
+3. Backend Health Check sauber anbinden
+4. DiagCenter konkretisieren
+5. Decision Assistant ergänzen
 ```
 
 ## Pflege Ablauf

--- a/frontend/src/sound-engine.ts
+++ b/frontend/src/sound-engine.ts
@@ -10,6 +10,7 @@ export type SoundEvent =
   | "ui_toggle";
 
 type OscillatorKind = OscillatorType;
+type AudioContextConstructor = new () => AudioContext;
 
 class JarvisSoundEngine {
   private ctx: AudioContext | null = null;
@@ -17,6 +18,7 @@ class JarvisSoundEngine {
   private enabled = false;
   private volume = 0.22;
   private mode = "idle";
+  private unlocked = false;
   private thinkingOsc: OscillatorNode | null = null;
   private thinkingGain: GainNode | null = null;
 
@@ -24,26 +26,40 @@ class JarvisSoundEngine {
     this.enabled = enabled;
     this.volume = Math.max(0, Math.min(1, volume));
     if (this.master) this.master.gain.value = this.volume;
-    if (!enabled) this.stopThinking();
+    if (!enabled) {
+      this.unlocked = false;
+      this.stopThinking();
+    }
   }
 
   async unlock() {
+    if (!this.enabled) return false;
     if (!this.ctx) this.createContext();
-    if (this.ctx?.state === "suspended") await this.ctx.resume();
+    try {
+      if (this.ctx?.state === "suspended") await this.ctx.resume();
+      this.unlocked = this.ctx?.state === "running";
+      return this.unlocked;
+    } catch {
+      this.unlocked = false;
+      return false;
+    }
+  }
+
+  isUnlocked() {
+    return this.unlocked && this.ctx?.state === "running";
   }
 
   setMode(mode: string) {
     if (mode === this.mode) return;
     this.mode = mode;
-    if (!this.enabled) return;
+    if (!this.enabled || !this.isUnlocked()) return;
     if (mode === "thinking") this.startThinking();
     else this.stopThinking();
     if (mode === "listening") this.play("listening");
   }
 
   play(event: SoundEvent | string) {
-    if (!this.enabled) return;
-    this.ensureRunning();
+    if (!this.enabled || !this.isUnlocked()) return;
     switch (event) {
       case "agent_route":
         this.beep(620, 0.045, 0.08, "square");
@@ -83,19 +99,17 @@ class JarvisSoundEngine {
   }
 
   private createContext() {
-    this.ctx = new AudioContext();
+    const win = window as Window & { webkitAudioContext?: AudioContextConstructor };
+    const AudioCtor = window.AudioContext || win.webkitAudioContext;
+    if (!AudioCtor) return;
+    this.ctx = new AudioCtor();
     this.master = this.ctx.createGain();
     this.master.gain.value = this.volume;
     this.master.connect(this.ctx.destination);
   }
 
-  private ensureRunning() {
-    if (!this.ctx) this.createContext();
-    if (this.ctx?.state === "suspended") void this.ctx.resume();
-  }
-
   private beep(frequency: number, duration: number, gainValue: number, type: OscillatorKind = "sine", delay = 0) {
-    if (!this.ctx || !this.master) return;
+    if (!this.ctx || !this.master || !this.isUnlocked()) return;
     const start = this.ctx.currentTime + delay;
     const osc = this.ctx.createOscillator();
     const gain = this.ctx.createGain();
@@ -111,7 +125,7 @@ class JarvisSoundEngine {
   }
 
   private sweep(from: number, to: number, duration: number, gainValue: number) {
-    if (!this.ctx || !this.master) return;
+    if (!this.ctx || !this.master || !this.isUnlocked()) return;
     const start = this.ctx.currentTime;
     const osc = this.ctx.createOscillator();
     const gain = this.ctx.createGain();
@@ -128,8 +142,7 @@ class JarvisSoundEngine {
   }
 
   private startThinking() {
-    this.ensureRunning();
-    if (!this.ctx || !this.master || this.thinkingOsc) return;
+    if (!this.ctx || !this.master || !this.isUnlocked() || this.thinkingOsc) return;
     const osc = this.ctx.createOscillator();
     const gain = this.ctx.createGain();
     osc.type = "sine";


### PR DESCRIPTION
## Beschreibung

Behebt das wahrscheinlichste Sound Problem: Browser blockieren Web Audio nach Reload, obwohl Sound im HUD als aktiviert gespeichert ist.

## Änderungen

- Sound Engine spielt nur noch, wenn der AudioContext wirklich freigeschaltet ist
- `unlock()` liefert jetzt einen echten Erfolgsstatus zurück
- `isUnlocked()` ergänzt
- WebKit Fallback für `webkitAudioContext` ergänzt
- Sound Events laufen nicht mehr stumm in einen gesperrten AudioContext
- CHANGELOG.md Eintrag `B6.6.13`
- PROJECT_STATUS.md gemäß Pflege Regel aktualisiert

## Hinweis

Der nächste kleine Frontend Schritt bleibt offen: Wenn Sound gespeichert aktiv ist, sollte der nächste Nutzerklick automatisch einen Re Unlock versuchen oder der HUD Status sollte klar anzeigen, dass Sound zwar aktiviert, aber noch nicht freigeschaltet ist.

## Warum

Autoplay Regeln erlauben Audio erst nach bewusster Nutzeraktion. Nach einem Reload kann `jarvis_sound_enabled=true` aus localStorage geladen werden, der AudioContext ist aber trotzdem wieder gesperrt.