### PR TITLE
fix: re-unlock JARVIS sound after reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Alle nennenswerten Änderungen an diesem Projekt werden in dieser Datei dokument
 
 Das Format orientiert sich an Keep a Changelog. Versionen folgen dem Projektstand B1 bis B6 und den Build Versionen von JARVIS.
 
+## [B6.6.14] - 2026-05-01
+
+### Fixed
+
+- Sound Re Unlock im Frontend ergänzt, damit ein gespeicherter aktiver Soundstatus nach Reload beim nächsten Nutzerklick wieder sauber entsperrt wird.
+- Stabile Listener Referenz für `pointerdown` und `keydown` ergänzt, damit Unlock Listener korrekt entfernt werden können.
+
+### Changed
+
+- Sound Engine setzt bei aktivem Sound und gesperrtem AudioContext automatisch einen Re Unlock Listener, statt dauerhaft stumm zu bleiben.
+
 ## [B6.6.13] - 2026-05-01
 
 ### Fixed

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -38,12 +38,19 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 | LifeOS private Config | erledigt | `config/lifeos.json` wird bevorzugt geladen und über `.gitignore` aus dem Repository gehalten |
 | LifeOS Roadmap | erledigt | Ausgearbeitete Upgrade Roadmap liegt unter `docs/lifeos-roadmap.md` |
 | LifeOS persönliche Vorlage | erledigt | Skript und Anleitung zum Erzeugen der privaten `config/lifeos.json` vorhanden |
-| JARVIS Sound Layer | in Arbeit | Lokaler Web Audio Sound Layer vorhanden. Unlock Verhalten wurde robuster gemacht, Frontend Re Unlock nach Reload bleibt als Feinschliff offen |
+| JARVIS Sound Layer | erledigt | Lokaler Web Audio Sound Layer vorhanden. Re Unlock nach Reload ist vorbereitet |
 | Installer | offen | Installer muss weiter auf echte Endanwender Robustheit geprüft werden |
 | Backend Integration | offen | LifeOS liest noch keine echten Daten aus Backend oder lokaler Runtime |
 | Tests und CI | vorhanden | CI ist angelegt, muss bei größeren Dependency Updates aufmerksam geprüft werden |
 
 ## Erledigte Updates
+
+### B6.6.14
+
+- Sound Re Unlock im Frontend ergänzt.
+- Sound Engine setzt bei aktivem Sound und gesperrtem AudioContext automatisch Listener für den nächsten Nutzerklick oder Tastendruck.
+- Listener nutzen eine stabile Referenz und können korrekt entfernt werden.
+- Changelog und PROJECT_STATUS gemäß Pflege Regel aktualisiert.
 
 ### B6.6.13
 
@@ -130,7 +137,6 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 
 | Priorität | Thema | Status | Nächster Schritt |
 |---|---|---|---|
-| Hoch | Sound Re Unlock im Frontend | offen | Wenn Sound gespeichert aktiv ist, beim nächsten Nutzerklick AudioContext erneut unlocken und Status klar anzeigen |
 | Hoch | Installer Prüfung | offen | Start, First Setup, Python Erkennung und PowerShell ExecutionPolicy erneut testen |
 | Mittel | Backend Health Check | offen | lokalen `/health` Check sauber mit Frontend und Installer verbinden |
 | Mittel | DiagCenter | offen | Diagnose Modul für Python, Node, Ports, Config und Logs konkretisieren |
@@ -157,7 +163,7 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 
 | Risiko | Einschätzung | Empfehlung |
 |---|---|---|
-| Browser Autoplay blockiert Sound nach Reload | hoch | Sound braucht nach Reload eine bewusste Nutzeraktion oder einen klaren Re Unlock Ablauf |
+| Browser Autoplay blockiert Sound nach Reload | reduziert | Re Unlock ist vorbereitet, muss lokal im Browser getestet werden |
 | Dependabot Major Updates | hoch | React, TypeScript, Vite und Actions Major Updates nicht blind mergen |
 | Installer Fehler bei Endanwendern | hoch | Installer weiterhin als eigener Schwerpunkt behandeln |
 | Private Daten im Repo | reduziert | `config/lifeos.json` ist ignoriert, trotzdem vor Commits prüfen |
@@ -165,16 +171,16 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 
 ## Nächster sinnvoller Schritt
 
-Nach dem Sound Engine Fix ist der nächste sinnvolle Schritt der kleine Frontend Feinschliff: Wenn Sound gespeichert aktiv ist, soll der nächste Nutzerklick den AudioContext wieder freischalten und der HUD Status soll nicht irreführend wirken.
+Nach dem Sound Re Unlock ist der nächste sinnvolle Schritt die Installer Robustheit. Dafür sollen Start, First Setup, Python Erkennung und PowerShell ExecutionPolicy erneut geprüft werden.
 
 Empfohlene Reihenfolge:
 
 ```text
-1. Sound Re Unlock im Frontend ergänzen
-2. Installer Robustheit erneut prüfen
-3. Backend Health Check sauber anbinden
-4. DiagCenter konkretisieren
-5. Decision Assistant ergänzen
+1. Installer Robustheit erneut prüfen
+2. Backend Health Check sauber anbinden
+3. DiagCenter konkretisieren
+4. Decision Assistant ergänzen
+5. Private Project Manager ergänzen
 ```
 
 ## Pflege Ablauf

--- a/frontend/src/sound-engine.ts
+++ b/frontend/src/sound-engine.ts
@@ -20,6 +20,9 @@ class JarvisSoundEngine {
   private mode = "idle";
   private unlocked = false;
   private unlockListenerActive = false;
+  private readonly unlockOnGesture = () => {
+    void this.unlock();
+  };
   private thinkingOsc: OscillatorNode | null = null;
   private thinkingGain: GainNode | null = null;
 
@@ -125,18 +128,15 @@ class JarvisSoundEngine {
   private armUserGestureUnlock() {
     if (this.unlockListenerActive || typeof window === "undefined") return;
     this.unlockListenerActive = true;
-    const unlockOnGesture = () => {
-      void this.unlock();
-    };
-    window.addEventListener("pointerdown", unlockOnGesture, { passive: true });
-    window.addEventListener("keydown", unlockOnGesture);
+    window.addEventListener("pointerdown", this.unlockOnGesture, { passive: true });
+    window.addEventListener("keydown", this.unlockOnGesture);
   }
 
   private disarmUserGestureUnlock() {
     if (!this.unlockListenerActive || typeof window === "undefined") return;
     this.unlockListenerActive = false;
-    window.removeEventListener("pointerdown", () => void this.unlock());
-    window.removeEventListener("keydown", () => void this.unlock());
+    window.removeEventListener("pointerdown", this.unlockOnGesture);
+    window.removeEventListener("keydown", this.unlockOnGesture);
   }
 
   private beep(frequency: number, duration: number, gainValue: number, type: OscillatorKind = "sine", delay = 0) {

--- a/frontend/src/sound-engine.ts
+++ b/frontend/src/sound-engine.ts
@@ -19,6 +19,7 @@ class JarvisSoundEngine {
   private volume = 0.22;
   private mode = "idle";
   private unlocked = false;
+  private unlockListenerActive = false;
   private thinkingOsc: OscillatorNode | null = null;
   private thinkingGain: GainNode | null = null;
 
@@ -26,9 +27,11 @@ class JarvisSoundEngine {
     this.enabled = enabled;
     this.volume = Math.max(0, Math.min(1, volume));
     if (this.master) this.master.gain.value = this.volume;
+    if (enabled && !this.isUnlocked()) this.armUserGestureUnlock();
     if (!enabled) {
       this.unlocked = false;
       this.stopThinking();
+      this.disarmUserGestureUnlock();
     }
   }
 
@@ -38,9 +41,17 @@ class JarvisSoundEngine {
     try {
       if (this.ctx?.state === "suspended") await this.ctx.resume();
       this.unlocked = this.ctx?.state === "running";
+      if (this.unlocked) {
+        this.disarmUserGestureUnlock();
+        this.play("ui_toggle");
+        this.setMode(this.mode);
+      } else {
+        this.armUserGestureUnlock();
+      }
       return this.unlocked;
     } catch {
       this.unlocked = false;
+      this.armUserGestureUnlock();
       return false;
     }
   }
@@ -59,7 +70,10 @@ class JarvisSoundEngine {
   }
 
   play(event: SoundEvent | string) {
-    if (!this.enabled || !this.isUnlocked()) return;
+    if (!this.enabled || !this.isUnlocked()) {
+      if (this.enabled) this.armUserGestureUnlock();
+      return;
+    }
     switch (event) {
       case "agent_route":
         this.beep(620, 0.045, 0.08, "square");
@@ -106,6 +120,23 @@ class JarvisSoundEngine {
     this.master = this.ctx.createGain();
     this.master.gain.value = this.volume;
     this.master.connect(this.ctx.destination);
+  }
+
+  private armUserGestureUnlock() {
+    if (this.unlockListenerActive || typeof window === "undefined") return;
+    this.unlockListenerActive = true;
+    const unlockOnGesture = () => {
+      void this.unlock();
+    };
+    window.addEventListener("pointerdown", unlockOnGesture, { passive: true });
+    window.addEventListener("keydown", unlockOnGesture);
+  }
+
+  private disarmUserGestureUnlock() {
+    if (!this.unlockListenerActive || typeof window === "undefined") return;
+    this.unlockListenerActive = false;
+    window.removeEventListener("pointerdown", () => void this.unlock());
+    window.removeEventListener("keydown", () => void this.unlock());
   }
 
   private beep(frequency: number, duration: number, gainValue: number, type: OscillatorKind = "sine", delay = 0) {


### PR DESCRIPTION
## Beschreibung

Ergänzt einen Frontend Re Unlock für den JARVIS Sound Layer. Wenn Sound gespeichert aktiv ist, der Browser den AudioContext nach Reload aber wieder sperrt, setzt die Sound Engine automatisch Listener auf die nächste Nutzeraktion.

## Änderungen

- Sound Engine setzt bei aktivem Sound und gesperrtem AudioContext einen Re Unlock Listener
- Re Unlock reagiert auf `pointerdown` und `keydown`
- stabile Listener Referenz ergänzt, damit Listener korrekt entfernt werden
- Sound Events bleiben blockiert, bis der AudioContext wirklich freigeschaltet ist
- Changelog Eintrag `B6.6.14`
- PROJECT_STATUS.md gemäß Pflege Regel aktualisiert

## Warum

Browser blockieren Audio nach Reload oft erneut, auch wenn der Soundstatus im HUD gespeichert aktiv ist. Dadurch wirkt Sound aktiv, bleibt aber stumm. Der Re Unlock löst das beim nächsten bewussten Nutzerklick oder Tastendruck.

## Sicherheit

- keine externen Assets
- keine Telemetrie
- keine privaten Daten
- Sound bleibt nur nach Nutzeraktion aktiv