### PR TITLE
feat: add installer readiness check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ Alle nennenswerten Änderungen an diesem Projekt werden in dieser Datei dokument
 
 Das Format orientiert sich an Keep a Changelog. Versionen folgen dem Projektstand B1 bis B6 und den Build Versionen von JARVIS.
 
+## [B6.6.15] - 2026-05-01
+
+### Added
+
+- Installer Readiness Check unter `scripts/maintenance/check-installer-readiness.ps1` ergänzt.
+- Dokumentation `docs/installer-readiness.md` ergänzt.
+- Vorprüfung für PowerShell, Root Dateien, Python, Node.js, npm, winget, Ollama, Ports und LifeOS Config ergänzt.
+
+### Changed
+
+- Installer Robustheit wird um einen nicht destruktiven Diagnose Schritt vor der eigentlichen Installation erweitert.
+
 ## [B6.6.14] - 2026-05-01
 
 ### Fixed

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -39,11 +39,19 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 | LifeOS Roadmap | erledigt | Ausgearbeitete Upgrade Roadmap liegt unter `docs/lifeos-roadmap.md` |
 | LifeOS persönliche Vorlage | erledigt | Skript und Anleitung zum Erzeugen der privaten `config/lifeos.json` vorhanden |
 | JARVIS Sound Layer | erledigt | Lokaler Web Audio Sound Layer vorhanden. Re Unlock nach Reload ist vorbereitet |
-| Installer | offen | Installer muss weiter auf echte Endanwender Robustheit geprüft werden |
+| Installer Readiness Check | erledigt | Nicht destruktiver Vorab Check für Installer Voraussetzungen vorhanden |
+| Installer | in Arbeit | Installer selbst ist robust, zusätzlicher Vorab Check ergänzt. Lokaler echter Endanwender Test bleibt offen |
 | Backend Integration | offen | LifeOS liest noch keine echten Daten aus Backend oder lokaler Runtime |
 | Tests und CI | vorhanden | CI ist angelegt, muss bei größeren Dependency Updates aufmerksam geprüft werden |
 
 ## Erledigte Updates
+
+### B6.6.15
+
+- Installer Readiness Check unter `scripts/maintenance/check-installer-readiness.ps1` ergänzt.
+- Dokumentation `docs/installer-readiness.md` ergänzt.
+- Vorprüfung für PowerShell, wichtige Root Dateien, Python, Node.js, npm, winget, Ollama, Ports und LifeOS Config ergänzt.
+- Changelog und PROJECT_STATUS gemäß Pflege Regel aktualisiert.
 
 ### B6.6.14
 
@@ -131,13 +139,12 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 - Dependabot ergänzt.
 - Issue und Pull Request Templates ergänzt.
 - Changelog und Contribution Dokumentation ergänzt.
-- Installer Logik teilweise verbessert.
 
 ## Offene Updates und Todos
 
 | Priorität | Thema | Status | Nächster Schritt |
 |---|---|---|---|
-| Hoch | Installer Prüfung | offen | Start, First Setup, Python Erkennung und PowerShell ExecutionPolicy erneut testen |
+| Hoch | Installer Endanwender Test | offen | Readiness Check, INSTALL_JARVIS.bat und START_JARVIS.bat auf frischem Windows lokal ausführen |
 | Mittel | Backend Health Check | offen | lokalen `/health` Check sauber mit Frontend und Installer verbinden |
 | Mittel | DiagCenter | offen | Diagnose Modul für Python, Node, Ports, Config und Logs konkretisieren |
 | Mittel | Decision Assistant | offen | Optionen, Aufwand, Risiko, Nutzen und Empfehlung als Schema ergänzen |
@@ -156,6 +163,7 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 | `docs/lifeos-roadmap.md` | Ausgearbeitete LifeOS Upgrade Roadmap mit Modulen, Nutzen, Umsetzung und Akzeptanzkriterien |
 | `docs/lifeos-global-upgrade.md` | Grundkonzept des LifeOS Global Upgrade |
 | `docs/lifeos-private-config.md` | Anleitung für die private lokale LifeOS Konfiguration |
+| `docs/installer-readiness.md` | Anleitung für den nicht destruktiven Installer Vorab Check |
 | `CHANGELOG.md` | Versionierte Änderungen |
 | `PROJECT_STATUS.md` | Projektstand, offene Todos, Risiken und nächster sinnvoller Schritt |
 
@@ -163,24 +171,24 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 
 | Risiko | Einschätzung | Empfehlung |
 |---|---|---|
+| Installer Fehler bei Endanwendern | reduziert | Readiness Check vorhanden, echter Test auf frischem Windows bleibt nötig |
 | Browser Autoplay blockiert Sound nach Reload | reduziert | Re Unlock ist vorbereitet, muss lokal im Browser getestet werden |
 | Dependabot Major Updates | hoch | React, TypeScript, Vite und Actions Major Updates nicht blind mergen |
-| Installer Fehler bei Endanwendern | hoch | Installer weiterhin als eigener Schwerpunkt behandeln |
 | Private Daten im Repo | reduziert | `config/lifeos.json` ist ignoriert, trotzdem vor Commits prüfen |
 | Roadmap wird zu groß ohne Umsetzung | mittel | pro PR nur ein klarer Roadmap Punkt umsetzen |
 
 ## Nächster sinnvoller Schritt
 
-Nach dem Sound Re Unlock ist der nächste sinnvolle Schritt die Installer Robustheit. Dafür sollen Start, First Setup, Python Erkennung und PowerShell ExecutionPolicy erneut geprüft werden.
+Nach dem Installer Readiness Check ist der nächste sinnvolle Schritt der Backend Health Check. Dafür soll der bestehende `/health` oder ein klarer Health Endpunkt sauber mit Frontend, Startskript und Diagnose verbunden werden.
 
 Empfohlene Reihenfolge:
 
 ```text
-1. Installer Robustheit erneut prüfen
-2. Backend Health Check sauber anbinden
-3. DiagCenter konkretisieren
-4. Decision Assistant ergänzen
-5. Private Project Manager ergänzen
+1. Backend Health Check sauber anbinden
+2. DiagCenter konkretisieren
+3. Decision Assistant ergänzen
+4. Private Project Manager ergänzen
+5. Release ZIP Workflow testen
 ```
 
 ## Pflege Ablauf

--- a/docs/installer-readiness.md
+++ b/docs/installer-readiness.md
@@ -1,0 +1,70 @@
+# Installer Readiness Check
+
+Der Installer Readiness Check ist eine nicht destruktive Vorprüfung für die Windows Installation.
+
+Er installiert nichts, ändert keine Systemwerte und soll typische Fehler vor `INSTALL_JARVIS.ps1` sichtbar machen.
+
+## Ausführen
+
+Im Repository Root:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\maintenance\check-installer-readiness.ps1
+```
+
+## Was geprüft wird
+
+```text
+PowerShell Version
+wichtige Root Dateien
+backend, frontend und config Ordner
+Python 3.10 oder neuer
+Node.js
+npm
+winget
+Ollama CLI und Port 11434
+Port 8000
+Port 5173
+LifeOS Beispielkonfiguration
+LifeOS private Konfiguration
+```
+
+## Ergebnis
+
+Der Check unterscheidet drei Zustände:
+
+```text
+OK    = bereit
+WARN  = Hinweis, Installation kann oft trotzdem weitergehen
+FAIL  = Problem muss vor Installation behoben werden
+```
+
+Bei `FAIL` endet das Skript mit ExitCode 1.
+
+## Warum dieser Check existiert
+
+Der Installer selbst kann viele Dinge reparieren oder installieren. Für echte Endanwender ist es aber besser, vorab klar zu sehen, warum eine Installation scheitern könnte.
+
+Typische Problemfälle:
+
+```text
+Python fehlt oder ist nur als Windows Store Dummy vorhanden
+Node.js oder npm fehlen
+PowerShell ist zu alt
+Ports sind bereits belegt
+Ollama ist nicht erreichbar
+LifeOS Beispielkonfiguration fehlt
+```
+
+## Wichtig
+
+Der Readiness Check ersetzt den Installer nicht. Er ist ein vorgeschalteter Diagnose Schritt.
+
+Empfohlene Reihenfolge:
+
+```text
+1. check-installer-readiness.ps1 ausführen
+2. Falls FAIL, Problem beheben
+3. INSTALL_JARVIS.bat starten
+4. Bei Startproblemen START_JARVIS.bat testen
+```

--- a/scripts/maintenance/check-installer-readiness.ps1
+++ b/scripts/maintenance/check-installer-readiness.ps1
@@ -1,0 +1,193 @@
+<#
+.SYNOPSIS
+Checks whether the local checkout is ready for a JARVIS Windows installation.
+
+.DESCRIPTION
+This script performs non destructive preflight checks for the Windows installer.
+It does not install packages and does not modify the system. It is intended to catch common end user problems before running INSTALL_JARVIS.ps1.
+
+.EXAMPLE
+powershell -ExecutionPolicy Bypass -File scripts\maintenance\check-installer-readiness.ps1
+#>
+
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+$Root = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+$Failures = New-Object System.Collections.Generic.List[string]
+$Warnings = New-Object System.Collections.Generic.List[string]
+
+function Write-Result {
+    param(
+        [string]$Label,
+        [string]$Status,
+        [string]$Message = ""
+    )
+    $color = "Gray"
+    if ($Status -eq "OK") { $color = "Green" }
+    elseif ($Status -eq "WARN") { $color = "Yellow" }
+    elseif ($Status -eq "FAIL") { $color = "Red" }
+    Write-Host ("[{0}] {1}" -f $Status, $Label) -ForegroundColor $color
+    if ($Message) { Write-Host "      $Message" -ForegroundColor DarkGray }
+}
+
+function Add-Fail {
+    param([string]$Label, [string]$Message)
+    $Failures.Add("$Label - $Message") | Out-Null
+    Write-Result $Label "FAIL" $Message
+}
+
+function Add-Warn {
+    param([string]$Label, [string]$Message)
+    $Warnings.Add("$Label - $Message") | Out-Null
+    Write-Result $Label "WARN" $Message
+}
+
+function Add-Ok {
+    param([string]$Label, [string]$Message = "")
+    Write-Result $Label "OK" $Message
+}
+
+function Invoke-Capture {
+    param(
+        [string]$Command,
+        [string[]]$Arguments = @(),
+        [int]$TimeoutSeconds = 10
+    )
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $Command
+    $psi.Arguments = ($Arguments -join " ")
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.UseShellExecute = $false
+    $psi.CreateNoWindow = $true
+    try {
+        $p = [System.Diagnostics.Process]::Start($psi)
+        if (-not $p.WaitForExit($TimeoutSeconds * 1000)) {
+            try { $p.Kill() } catch {}
+            return @{ Ok=$false; Output=""; Error="Timeout"; ExitCode=-1 }
+        }
+        return @{ Ok=($p.ExitCode -eq 0); Output=$p.StandardOutput.ReadToEnd().Trim(); Error=$p.StandardError.ReadToEnd().Trim(); ExitCode=$p.ExitCode }
+    } catch {
+        return @{ Ok=$false; Output=""; Error=$_.Exception.Message; ExitCode=-2 }
+    }
+}
+
+function Test-Port {
+    param([int]$Port)
+    $client = $null
+    try {
+        $client = New-Object Net.Sockets.TcpClient
+        $iar = $client.BeginConnect("127.0.0.1", $Port, $null, $null)
+        $ok = $iar.AsyncWaitHandle.WaitOne(500, $false)
+        if ($ok) { $client.EndConnect($iar) }
+        return $ok
+    } catch {
+        return $false
+    } finally {
+        if ($client) { $client.Close() }
+    }
+}
+
+function Parse-PythonVersion {
+    param([string]$Text)
+    if ($Text -match "Python\s+(\d+)\.(\d+)\.(\d+)") { return [version]"$($Matches[1]).$($Matches[2]).$($Matches[3])" }
+    if ($Text -match "Python\s+(\d+)\.(\d+)") { return [version]"$($Matches[1]).$($Matches[2]).0" }
+    return $null
+}
+
+function Test-Python {
+    $candidates = @(
+        @{ Command="py"; Args=@("-3") },
+        @{ Command="python"; Args=@() },
+        @{ Command="python3"; Args=@() }
+    )
+    foreach ($candidate in $candidates) {
+        $cmd = Get-Command $candidate.Command -ErrorAction SilentlyContinue
+        if (-not $cmd) { continue }
+        if ($cmd.Source -match "WindowsApps") { continue }
+        $result = Invoke-Capture $candidate.Command ($candidate.Args + @("--version"))
+        $text = (($result.Output, $result.Error) -join " ").Trim()
+        $version = Parse-PythonVersion $text
+        if ($version -and $version.Major -eq 3 -and $version -ge [version]"3.10.0") {
+            $real = Invoke-Capture $candidate.Command ($candidate.Args + @("-c", "import sys; print(sys.executable)"))
+            if ($real.Output -notmatch "WindowsApps") {
+                Add-Ok "Python 3.10+" "$text using $($real.Output)"
+                return
+            }
+        }
+    }
+    Add-Fail "Python 3.10+" "No valid Python 3.10+ found. Store dummy paths are ignored."
+}
+
+Write-Host ""
+Write-Host "JARVIS installer readiness check" -ForegroundColor Cyan
+Write-Host "Root: $Root" -ForegroundColor DarkGray
+Write-Host ""
+
+if ($PSVersionTable.PSVersion.Major -ge 5) { Add-Ok "PowerShell" $PSVersionTable.PSVersion.ToString() } else { Add-Fail "PowerShell" "PowerShell 5 or newer is required." }
+
+foreach ($file in @("INSTALL_JARVIS.ps1", "INSTALL_JARVIS.bat", "FIRST_SETUP.ps1", "START_JARVIS.ps1", "START_JARVIS.bat")) {
+    $path = Join-Path $Root $file
+    if (Test-Path $path) { Add-Ok "Required file $file" } else { Add-Fail "Required file $file" "Missing from repository root." }
+}
+
+foreach ($dir in @("backend", "frontend", "config")) {
+    $path = Join-Path $Root $dir
+    if (Test-Path $path) { Add-Ok "Required directory $dir" } else { Add-Fail "Required directory $dir" "Missing directory." }
+}
+
+Test-Python
+
+$node = Get-Command "node" -ErrorAction SilentlyContinue
+if ($node) {
+    $version = Invoke-Capture "node" @("--version")
+    Add-Ok "Node.js" $version.Output
+} else {
+    Add-Fail "Node.js" "node command not found. Install Node.js LTS."
+}
+
+$npm = Get-Command "npm.cmd" -ErrorAction SilentlyContinue
+if (-not $npm) { $npm = Get-Command "npm" -ErrorAction SilentlyContinue }
+if ($npm) {
+    $version = Invoke-Capture $npm.Source @("--version")
+    Add-Ok "npm" $version.Output
+} else {
+    Add-Fail "npm" "npm command not found. Install Node.js LTS."
+}
+
+$winget = Get-Command "winget" -ErrorAction SilentlyContinue
+if ($winget) { Add-Ok "winget" $winget.Source } else { Add-Warn "winget" "Missing. Automatic dependency installation may not work." }
+
+$ollama = Get-Command "ollama" -ErrorAction SilentlyContinue
+if ($ollama) {
+    Add-Ok "Ollama CLI" $ollama.Source
+    if (Test-Port 11434) { Add-Ok "Ollama port 11434" "reachable" } else { Add-Warn "Ollama port 11434" "not reachable. Installer can continue, model pull may be skipped." }
+} else {
+    Add-Warn "Ollama CLI" "Missing. Installer can continue with -SkipModel or install Ollama first."
+}
+
+if (Test-Port 8000) { Add-Warn "Port 8000" "Already in use. START_JARVIS may attach to existing backend or conflict." } else { Add-Ok "Port 8000" "free" }
+if (Test-Port 5173) { Add-Warn "Port 5173" "Already in use. Dev frontend may conflict." } else { Add-Ok "Port 5173" "free" }
+
+$lifeosExample = Join-Path $Root "config\lifeos.example.json"
+if (Test-Path $lifeosExample) { Add-Ok "LifeOS example config" } else { Add-Fail "LifeOS example config" "config/lifeos.example.json missing." }
+
+$lifeosPrivate = Join-Path $Root "config\lifeos.json"
+if (Test-Path $lifeosPrivate) { Add-Ok "LifeOS private config" "present and should stay local" } else { Add-Warn "LifeOS private config" "Missing. FIRST_SETUP.ps1 should create it from the example file." }
+
+Write-Host ""
+if ($Failures.Count -gt 0) {
+    Write-Host "Readiness check failed" -ForegroundColor Red
+    $Failures | ForEach-Object { Write-Host " - $_" -ForegroundColor Red }
+    exit 1
+}
+
+if ($Warnings.Count -gt 0) {
+    Write-Host "Readiness check completed with warnings" -ForegroundColor Yellow
+    $Warnings | ForEach-Object { Write-Host " - $_" -ForegroundColor Yellow }
+    exit 0
+}
+
+Write-Host "Readiness check passed" -ForegroundColor Green
+exit 0


### PR DESCRIPTION
## Beschreibung

Ergänzt einen nicht destruktiven Installer Readiness Check für Windows.

## Änderungen

- Neues Skript `scripts/maintenance/check-installer-readiness.ps1`
- Neue Dokumentation `docs/installer-readiness.md`
- Changelog Eintrag `B6.6.15`
- PROJECT_STATUS.md gemäß Pflege Regel aktualisiert

## Was geprüft wird

- PowerShell Version
- wichtige Root Dateien
- backend, frontend und config Ordner
- Python 3.10 oder neuer, ohne Windows Store Dummy
- Node.js
- npm
- winget
- Ollama CLI und Port 11434
- Port 8000
- Port 5173
- LifeOS Beispielkonfiguration
- LifeOS private Konfiguration

## Nutzung

```powershell
powershell -ExecutionPolicy Bypass -File scripts\maintenance\check-installer-readiness.ps1
```

## Sicherheit

- installiert nichts
- löscht nichts
- ändert keine Systemwerte
- keine privaten Daten
- nur Diagnose vor der eigentlichen Installation