### PR TITLE
feat: verify backend health during startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ Alle nennenswerten Änderungen an diesem Projekt werden in dieser Datei dokument
 
 Das Format orientiert sich an Keep a Changelog. Versionen folgen dem Projektstand B1 bis B6 und den Build Versionen von JARVIS.
 
+## [B6.6.16] - 2026-05-01
+
+### Added
+
+- Backend Health Check im Startskript ergänzt.
+- Dokumentation `docs/backend-health-check.md` ergänzt.
+- `START_JARVIS.ps1` prüft nach Port 8000 jetzt zusätzlich `http://127.0.0.1:8000/health`.
+
+### Changed
+
+- JARVIS gilt beim Start erst als bereit, wenn Backend Port und Health Endpunkt erfolgreich antworten.
+
+### Fixed
+
+- Startskript erkennt besser, wenn zwar Port 8000 offen ist, der Backend Dienst aber nicht sauber antwortet.
+
 ## [B6.6.15] - 2026-05-01
 
 ### Added

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -40,11 +40,19 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 | LifeOS persönliche Vorlage | erledigt | Skript und Anleitung zum Erzeugen der privaten `config/lifeos.json` vorhanden |
 | JARVIS Sound Layer | erledigt | Lokaler Web Audio Sound Layer vorhanden. Re Unlock nach Reload ist vorbereitet |
 | Installer Readiness Check | erledigt | Nicht destruktiver Vorab Check für Installer Voraussetzungen vorhanden |
+| Backend Health Check | erledigt | Startskript prüft Port 8000 und `/health`, bevor JARVIS als bereit gilt |
 | Installer | in Arbeit | Installer selbst ist robust, zusätzlicher Vorab Check ergänzt. Lokaler echter Endanwender Test bleibt offen |
-| Backend Integration | offen | LifeOS liest noch keine echten Daten aus Backend oder lokaler Runtime |
+| Backend Integration | in Arbeit | Backend Health ist angebunden, weitere Diagnose Integration folgt |
 | Tests und CI | vorhanden | CI ist angelegt, muss bei größeren Dependency Updates aufmerksam geprüft werden |
 
 ## Erledigte Updates
+
+### B6.6.16
+
+- Backend Health Check im Startskript ergänzt.
+- `START_JARVIS.ps1` prüft nach Port 8000 zusätzlich `http://127.0.0.1:8000/health`.
+- Dokumentation `docs/backend-health-check.md` ergänzt.
+- Changelog und PROJECT_STATUS gemäß Pflege Regel aktualisiert.
 
 ### B6.6.15
 
@@ -145,8 +153,7 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 | Priorität | Thema | Status | Nächster Schritt |
 |---|---|---|---|
 | Hoch | Installer Endanwender Test | offen | Readiness Check, INSTALL_JARVIS.bat und START_JARVIS.bat auf frischem Windows lokal ausführen |
-| Mittel | Backend Health Check | offen | lokalen `/health` Check sauber mit Frontend und Installer verbinden |
-| Mittel | DiagCenter | offen | Diagnose Modul für Python, Node, Ports, Config und Logs konkretisieren |
+| Mittel | DiagCenter | offen | Diagnose Modul für Python, Node, Ports, Config, Backend Health und Logs konkretisieren |
 | Mittel | Decision Assistant | offen | Optionen, Aufwand, Risiko, Nutzen und Empfehlung als Schema ergänzen |
 | Mittel | Private Project Manager | offen | private Projekte mit Status, Blocker und nächstem Schritt führen |
 | Mittel | Health und Energy Radar | offen | Energie, Belastung, Pausen und Fokusfenster in die Planung aufnehmen |
@@ -164,6 +171,7 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 | `docs/lifeos-global-upgrade.md` | Grundkonzept des LifeOS Global Upgrade |
 | `docs/lifeos-private-config.md` | Anleitung für die private lokale LifeOS Konfiguration |
 | `docs/installer-readiness.md` | Anleitung für den nicht destruktiven Installer Vorab Check |
+| `docs/backend-health-check.md` | Anleitung zum Backend Health Check beim Start |
 | `CHANGELOG.md` | Versionierte Änderungen |
 | `PROJECT_STATUS.md` | Projektstand, offene Todos, Risiken und nächster sinnvoller Schritt |
 
@@ -171,7 +179,7 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 
 | Risiko | Einschätzung | Empfehlung |
 |---|---|---|
-| Installer Fehler bei Endanwendern | reduziert | Readiness Check vorhanden, echter Test auf frischem Windows bleibt nötig |
+| Installer Fehler bei Endanwendern | reduziert | Readiness Check und Health Check vorhanden, echter Test auf frischem Windows bleibt nötig |
 | Browser Autoplay blockiert Sound nach Reload | reduziert | Re Unlock ist vorbereitet, muss lokal im Browser getestet werden |
 | Dependabot Major Updates | hoch | React, TypeScript, Vite und Actions Major Updates nicht blind mergen |
 | Private Daten im Repo | reduziert | `config/lifeos.json` ist ignoriert, trotzdem vor Commits prüfen |
@@ -179,16 +187,16 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 
 ## Nächster sinnvoller Schritt
 
-Nach dem Installer Readiness Check ist der nächste sinnvolle Schritt der Backend Health Check. Dafür soll der bestehende `/health` oder ein klarer Health Endpunkt sauber mit Frontend, Startskript und Diagnose verbunden werden.
+Nach dem Backend Health Check ist der nächste sinnvolle Schritt das DiagCenter. Dort sollen Python, Node, Ports, Config, Backend Health und Logs in einem klaren Diagnose Modul zusammenlaufen.
 
 Empfohlene Reihenfolge:
 
 ```text
-1. Backend Health Check sauber anbinden
-2. DiagCenter konkretisieren
-3. Decision Assistant ergänzen
-4. Private Project Manager ergänzen
-5. Release ZIP Workflow testen
+1. DiagCenter konkretisieren
+2. Decision Assistant ergänzen
+3. Private Project Manager ergänzen
+4. Release ZIP Workflow testen
+5. Installer Endanwender Test durchführen
 ```
 
 ## Pflege Ablauf

--- a/START_JARVIS.ps1
+++ b/START_JARVIS.ps1
@@ -226,6 +226,26 @@ function Wait-Port {
   return $false
 }
 
+function Test-BackendHealth {
+  param([string]$Url = "http://127.0.0.1:8000/health")
+  try {
+    $result = Invoke-RestMethod -Uri $Url -Method Get -TimeoutSec 3
+    return @{ Ok=$true; Data=$result; Error="" }
+  } catch {
+    return @{ Ok=$false; Data=$null; Error=$_.Exception.Message }
+  }
+}
+
+function Wait-BackendHealth {
+  param([int]$Seconds = 20)
+  for($i=0; $i -lt ($Seconds * 2); $i++){
+    $health = Test-BackendHealth
+    if($health.Ok){ return $health }
+    Start-Sleep -Milliseconds 500
+  }
+  return Test-BackendHealth
+}
+
 function Invoke-Checked {
   param(
     [string]$Label,
@@ -306,7 +326,18 @@ if(-not (Test-Port 8000)){
   Start-Process -FilePath "cmd.exe" -ArgumentList "/k cd /d `"$Backend`" && `"$VenvPython`" -m uvicorn main:app --host 127.0.0.1 --port 8000" -WindowStyle Normal
   if(-not (Wait-Port 8000 20)){ Jv-Fail "Backend Port 8000 wurde nicht erreichbar" }
 }
-Jv-Ok "Backend erreichbar: http://127.0.0.1:8000"
+Jv-Ok "Backend Port erreichbar: http://127.0.0.1:8000"
+
+$health = Wait-BackendHealth -Seconds 20
+if(-not $health.Ok){
+  Jv-Fail "Backend /health antwortet nicht sauber: $($health.Error)"
+}
+$healthStatus = "ok"
+try {
+  if($health.Data.status){ $healthStatus = [string]$health.Data.status }
+  elseif($health.Data.ok){ $healthStatus = "ok" }
+} catch {}
+Jv-Ok "Backend Health OK: $healthStatus"
 
 if($DevFrontend){
   $npm = Get-NpmCmd

--- a/docs/backend-health-check.md
+++ b/docs/backend-health-check.md
@@ -1,0 +1,64 @@
+# Backend Health Check
+
+Der Backend Health Check stellt sicher, dass JARVIS nicht nur einen offenen Port hat, sondern dass der Backend Dienst wirklich antwortet.
+
+## Endpunkt
+
+```text
+http://127.0.0.1:8000/health
+```
+
+## Startverhalten
+
+`START_JARVIS.ps1` prüft jetzt nach dem Port Check zusätzlich den Health Endpunkt.
+
+Vorher reichte:
+
+```text
+Port 8000 ist offen
+```
+
+Jetzt gilt erst als bereit:
+
+```text
+Port 8000 ist offen
+/health antwortet erfolgreich
+```
+
+## Warum das wichtig ist
+
+Ein offener Port allein bedeutet nicht sicher, dass das Backend vollständig gestartet ist. Es kann sein, dass ein Prozess hängt, eine falsche Anwendung auf dem Port läuft oder der Dienst noch nicht bereit ist.
+
+Der Health Check reduziert diese Fälle.
+
+## Verhalten bei Fehler
+
+Wenn `/health` nicht sauber antwortet, bricht `START_JARVIS.ps1` mit einer klaren Fehlermeldung ab:
+
+```text
+Backend /health antwortet nicht sauber
+```
+
+Dann sollte geprüft werden:
+
+```text
+logs/start.log
+backend Logs
+Port 8000
+Python venv
+requirements
+```
+
+## Manuelle Prüfung
+
+Im Browser öffnen:
+
+```text
+http://127.0.0.1:8000/health
+```
+
+Oder in PowerShell:
+
+```powershell
+Invoke-RestMethod http://127.0.0.1:8000/health
+```


### PR DESCRIPTION
## Beschreibung

Verbindet den bestehenden Backend `/health` Endpunkt mit dem Startskript.

## Änderungen

- `START_JARVIS.ps1` prüft nach Port 8000 zusätzlich `http://127.0.0.1:8000/health`
- neuer Helper `Test-BackendHealth`
- neuer Helper `Wait-BackendHealth`
- klare Fehlermeldung, wenn `/health` nicht sauber antwortet
- neue Dokumentation `docs/backend-health-check.md`
- Changelog Eintrag `B6.6.16`
- PROJECT_STATUS.md gemäß Pflege Regel aktualisiert

## Warum

Ein offener Port bedeutet nicht automatisch, dass der Backend Dienst vollständig bereit ist. Der Health Check stellt sicher, dass JARVIS erst als bereit gilt, wenn das Backend wirklich antwortet.

## Manuelle Prüfung

```powershell
Invoke-RestMethod http://127.0.0.1:8000/health
```

## Sicherheit

- keine externen Dienste
- keine Telemetrie
- keine privaten Daten
- nur lokale Health Prüfung