### PR TITLE
feat: add DiagCenter aggregate endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ Alle nennenswerten Änderungen an diesem Projekt werden in dieser Datei dokument
 
 Das Format orientiert sich an Keep a Changelog. Versionen folgen dem Projektstand B1 bis B6 und den Build Versionen von JARVIS.
 
+## [B6.6.17] - 2026-05-01
+
+### Added
+
+- DiagCenter Sammel Endpunkt `GET /diagnostic/center` ergänzt.
+- DiagCenter bündelt Backend Health, Self Check, Dependencies, Ports, Logs, System Status, UseJARVIS Runtime und Awareness Runtime.
+- Dokumentation `docs/diagcenter.md` ergänzt.
+
+### Changed
+
+- Diagnoseinformationen sind nun über einen zentralen Endpunkt abrufbar, statt nur über einzelne Diagnose Routen verteilt zu sein.
+
 ## [B6.6.16] - 2026-05-01
 
 ### Added

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -41,11 +41,19 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 | JARVIS Sound Layer | erledigt | Lokaler Web Audio Sound Layer vorhanden. Re Unlock nach Reload ist vorbereitet |
 | Installer Readiness Check | erledigt | Nicht destruktiver Vorab Check für Installer Voraussetzungen vorhanden |
 | Backend Health Check | erledigt | Startskript prüft Port 8000 und `/health`, bevor JARVIS als bereit gilt |
+| DiagCenter | erledigt | Zentraler Sammel Endpunkt `/diagnostic/center` bündelt Health, Self Check, Dependencies, Ports, Logs und Runtime Status |
 | Installer | in Arbeit | Installer selbst ist robust, zusätzlicher Vorab Check ergänzt. Lokaler echter Endanwender Test bleibt offen |
-| Backend Integration | in Arbeit | Backend Health ist angebunden, weitere Diagnose Integration folgt |
+| Backend Integration | in Arbeit | Backend Health und DiagCenter sind angebunden, weitere Frontend Diagnose Integration folgt |
 | Tests und CI | vorhanden | CI ist angelegt, muss bei größeren Dependency Updates aufmerksam geprüft werden |
 
 ## Erledigte Updates
+
+### B6.6.17
+
+- DiagCenter Sammel Endpunkt `GET /diagnostic/center` ergänzt.
+- DiagCenter bündelt Backend Health, Self Check, Dependencies, Ports, Logs, System Status, UseJARVIS Runtime und Awareness Runtime.
+- Dokumentation `docs/diagcenter.md` ergänzt.
+- Changelog und PROJECT_STATUS gemäß Pflege Regel aktualisiert.
 
 ### B6.6.16
 
@@ -153,7 +161,7 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 | Priorität | Thema | Status | Nächster Schritt |
 |---|---|---|---|
 | Hoch | Installer Endanwender Test | offen | Readiness Check, INSTALL_JARVIS.bat und START_JARVIS.bat auf frischem Windows lokal ausführen |
-| Mittel | DiagCenter | offen | Diagnose Modul für Python, Node, Ports, Config, Backend Health und Logs konkretisieren |
+| Mittel | DiagCenter Frontend | offen | DiagCenter im Frontend sichtbar machen und Kernchecks lesbar darstellen |
 | Mittel | Decision Assistant | offen | Optionen, Aufwand, Risiko, Nutzen und Empfehlung als Schema ergänzen |
 | Mittel | Private Project Manager | offen | private Projekte mit Status, Blocker und nächstem Schritt führen |
 | Mittel | Health und Energy Radar | offen | Energie, Belastung, Pausen und Fokusfenster in die Planung aufnehmen |
@@ -172,6 +180,7 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 | `docs/lifeos-private-config.md` | Anleitung für die private lokale LifeOS Konfiguration |
 | `docs/installer-readiness.md` | Anleitung für den nicht destruktiven Installer Vorab Check |
 | `docs/backend-health-check.md` | Anleitung zum Backend Health Check beim Start |
+| `docs/diagcenter.md` | Anleitung zum zentralen DiagCenter Sammel Endpunkt |
 | `CHANGELOG.md` | Versionierte Änderungen |
 | `PROJECT_STATUS.md` | Projektstand, offene Todos, Risiken und nächster sinnvoller Schritt |
 
@@ -187,12 +196,12 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 
 ## Nächster sinnvoller Schritt
 
-Nach dem Backend Health Check ist der nächste sinnvolle Schritt das DiagCenter. Dort sollen Python, Node, Ports, Config, Backend Health und Logs in einem klaren Diagnose Modul zusammenlaufen.
+Nach dem DiagCenter Backend Endpunkt ist der nächste sinnvolle Schritt das DiagCenter Frontend. Dort sollen die Kernchecks aus `/diagnostic/center` sichtbar und verständlich dargestellt werden.
 
 Empfohlene Reihenfolge:
 
 ```text
-1. DiagCenter konkretisieren
+1. DiagCenter im Frontend sichtbar machen
 2. Decision Assistant ergänzen
 3. Private Project Manager ergänzen
 4. Release ZIP Workflow testen

--- a/backend/routes/diagnostic.py
+++ b/backend/routes/diagnostic.py
@@ -40,6 +40,10 @@ def api_diagnostic_deps():
 def api_diagnostic_deep():
     return system_service.api_diagnostic_deep()
 
+@router.get("/diagnostic/center")
+def api_diagnostic_center():
+    return system_service.api_diagnostic_center()
+
 @router.post("/diagnostic/analyze-text")
 async def api_diagnostic_analyze_text(req: Request):
     return await system_service.api_diagnostic_analyze_text(req=req)

--- a/backend/services/system.py
+++ b/backend/services/system.py
@@ -52,6 +52,51 @@ def api_diagnostic_deep():
         data["awareness_runtime"] = awareness_runtime.awareness_status()
     return data
 
+def api_diagnostic_center():
+    sections: Dict[str, Any] = {}
+    checks: List[Dict[str, Any]] = []
+
+    def capture(name: str, label: str, fn):
+        try:
+            data = fn()
+            sections[name] = data
+            ok = True
+            if isinstance(data, dict):
+                if data.get("ok") is False or data.get("status") in ("error", "failed", "offline"):
+                    ok = False
+            checks.append({"name": label, "ok": ok})
+        except Exception as exc:
+            sections[name] = {"ok": False, "error": str(exc)}
+            checks.append({"name": label, "ok": False, "error": str(exc)})
+
+    capture("health", "Backend Health", health)
+    capture("self_check", "Self Check", api_self_check)
+    capture("dependencies", "Dependencies", api_diagnostic_deps)
+    capture("ports", "Ports", api_diagnostic_ports)
+    capture("logs", "Logs", api_diagnostic_logs_list)
+    capture("system_status", "System Status", api_system_status)
+
+    runtime = usejarvis_runtime.runtime_status()
+    awareness = awareness_runtime.awareness_status()
+    sections["usejarvis_runtime"] = runtime
+    sections["awareness_runtime"] = awareness
+    checks.append({"name": "UseJARVIS Runtime", "ok": isinstance(runtime, dict)})
+    checks.append({"name": "Awareness Runtime", "ok": isinstance(awareness, dict)})
+
+    failed = [item for item in checks if not item.get("ok")]
+    return {
+        "ok": len(failed) == 0,
+        "status": "ok" if not failed else "attention",
+        "summary": {
+            "checks_total": len(checks),
+            "checks_ok": len(checks) - len(failed),
+            "checks_failed": len(failed),
+            "failed": failed,
+        },
+        "checks": checks,
+        "sections": sections,
+    }
+
 async def api_diagnostic_analyze_text(req: Request):
     return await core.api_diagnostic_analyze_text(req=req)
 

--- a/docs/diagcenter.md
+++ b/docs/diagcenter.md
@@ -1,0 +1,72 @@
+# DiagCenter
+
+DiagCenter ist der zentrale Sammelpunkt für JARVIS Diagnoseinformationen.
+
+## Endpunkt
+
+```text
+http://127.0.0.1:8000/diagnostic/center
+```
+
+## Zweck
+
+Vorher gab es mehrere einzelne Diagnose Endpunkte. DiagCenter bündelt die wichtigsten davon in einer gemeinsamen Übersicht.
+
+## Enthaltene Bereiche
+
+```text
+Backend Health
+Self Check
+Dependencies
+Ports
+Logs
+System Status
+UseJARVIS Runtime
+Awareness Runtime
+```
+
+## Antwortstruktur
+
+Der Endpunkt liefert:
+
+```text
+ok
+status
+summary
+checks
+sections
+```
+
+## Beispiel Prüfung
+
+In PowerShell:
+
+```powershell
+Invoke-RestMethod http://127.0.0.1:8000/diagnostic/center
+```
+
+Im Browser:
+
+```text
+http://127.0.0.1:8000/diagnostic/center
+```
+
+## Zielbild
+
+DiagCenter soll später auch im Frontend sichtbar werden und folgende Themen klar darstellen:
+
+```text
+Python
+Node.js
+Ports
+Backend Health
+LifeOS Config
+Logs
+Ollama
+Build Status
+Installer Status
+```
+
+## Sicherheitsprinzip
+
+DiagCenter führt keine Reparaturen aus. Es sammelt und bewertet nur lokale Diagnoseinformationen.


### PR DESCRIPTION
## Beschreibung

Ergänzt einen zentralen DiagCenter Sammel Endpunkt für JARVIS Diagnoseinformationen.

## Änderungen

- Neuer Endpunkt `GET /diagnostic/center`
- neue Service Funktion `api_diagnostic_center`
- bündelt vorhandene Checks statt neue Einzelprüfungen zu duplizieren
- neue Dokumentation `docs/diagcenter.md`
- Changelog Eintrag `B6.6.17`
- PROJECT_STATUS.md gemäß Pflege Regel aktualisiert

## Enthaltene Bereiche

- Backend Health
- Self Check
- Dependencies
- Ports
- Logs
- System Status
- UseJARVIS Runtime
- Awareness Runtime

## Nutzung

```powershell
Invoke-RestMethod http://127.0.0.1:8000/diagnostic/center
```

## Sicherheit

- keine Reparaturen
- keine Systemänderungen
- keine externen Dienste
- keine privaten Daten
- nur lokale Diagnoseauswertung