### PR TITLE
feat: add DiagCenter frontend page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ Alle nennenswerten Änderungen an diesem Projekt werden in dieser Datei dokument
 
 Das Format orientiert sich an Keep a Changelog. Versionen folgen dem Projektstand B1 bis B6 und den Build Versionen von JARVIS.
 
+## [B6.6.18] - 2026-05-01
+
+### Added
+
+- DiagCenter Frontend Seite unter `frontend/public/jarvis-diagcenter.html` ergänzt.
+- Launcher um `DIAGCENTER` Einstieg erweitert.
+- DiagCenter Frontend ruft `GET /diagnostic/center` ab und zeigt Checks, Sections und Raw JSON an.
+
+### Changed
+
+- Diagnose ist nun nicht nur per PowerShell oder Browser JSON erreichbar, sondern auch als lokale HUD Oberfläche sichtbar.
+
 ## [B6.6.17] - 2026-05-01
 
 ### Added

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -29,7 +29,7 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 | Bereich | Status | Hinweis |
 |---|---|---|
 | Repository Basis | erledigt | Projektstruktur, README, Changelog, Contribution Regeln und Security Hinweise vorhanden |
-| Launcher | erledigt | Startseite mit Global Overview, ULTRON Grid und LifeOS Einstieg vorhanden |
+| Launcher | erledigt | Startseite mit Global Overview, ULTRON Grid, LifeOS und DiagCenter Einstieg vorhanden |
 | Global Overview | erledigt | Stabile Weltkarten Ansicht als lokaler HUD Prototyp vorhanden |
 | ULTRON Grid | erledigt | JARVIS und ULTRON Command Grid mit Modus Umschaltung vorhanden |
 | LifeOS Command Center | erledigt | Erste sichtbare LifeOS Oberfläche vorhanden |
@@ -41,12 +41,20 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 | JARVIS Sound Layer | erledigt | Lokaler Web Audio Sound Layer vorhanden. Re Unlock nach Reload ist vorbereitet |
 | Installer Readiness Check | erledigt | Nicht destruktiver Vorab Check für Installer Voraussetzungen vorhanden |
 | Backend Health Check | erledigt | Startskript prüft Port 8000 und `/health`, bevor JARVIS als bereit gilt |
-| DiagCenter | erledigt | Zentraler Sammel Endpunkt `/diagnostic/center` bündelt Health, Self Check, Dependencies, Ports, Logs und Runtime Status |
+| DiagCenter Backend | erledigt | Zentraler Sammel Endpunkt `/diagnostic/center` bündelt Health, Self Check, Dependencies, Ports, Logs und Runtime Status |
+| DiagCenter Frontend | erledigt | Lokale HUD Seite `frontend/public/jarvis-diagcenter.html` zeigt Checks, Sections und Raw JSON |
 | Installer | in Arbeit | Installer selbst ist robust, zusätzlicher Vorab Check ergänzt. Lokaler echter Endanwender Test bleibt offen |
 | Backend Integration | in Arbeit | Backend Health und DiagCenter sind angebunden, weitere Frontend Diagnose Integration folgt |
 | Tests und CI | vorhanden | CI ist angelegt, muss bei größeren Dependency Updates aufmerksam geprüft werden |
 
 ## Erledigte Updates
+
+### B6.6.18
+
+- DiagCenter Frontend Seite `frontend/public/jarvis-diagcenter.html` ergänzt.
+- Launcher um `DIAGCENTER` Einstieg erweitert.
+- DiagCenter Frontend zeigt Checks, Sections und Raw JSON aus `/diagnostic/center`.
+- Changelog und PROJECT_STATUS gemäß Pflege Regel aktualisiert.
 
 ### B6.6.17
 
@@ -161,7 +169,6 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 | Priorität | Thema | Status | Nächster Schritt |
 |---|---|---|---|
 | Hoch | Installer Endanwender Test | offen | Readiness Check, INSTALL_JARVIS.bat und START_JARVIS.bat auf frischem Windows lokal ausführen |
-| Mittel | DiagCenter Frontend | offen | DiagCenter im Frontend sichtbar machen und Kernchecks lesbar darstellen |
 | Mittel | Decision Assistant | offen | Optionen, Aufwand, Risiko, Nutzen und Empfehlung als Schema ergänzen |
 | Mittel | Private Project Manager | offen | private Projekte mit Status, Blocker und nächstem Schritt führen |
 | Mittel | Health und Energy Radar | offen | Energie, Belastung, Pausen und Fokusfenster in die Planung aufnehmen |
@@ -196,16 +203,16 @@ Kein größerer Projektstand gilt als sauber abgeschlossen, wenn `PROJECT_STATUS
 
 ## Nächster sinnvoller Schritt
 
-Nach dem DiagCenter Backend Endpunkt ist der nächste sinnvolle Schritt das DiagCenter Frontend. Dort sollen die Kernchecks aus `/diagnostic/center` sichtbar und verständlich dargestellt werden.
+Nach dem DiagCenter Frontend ist der nächste sinnvolle Schritt der Decision Assistant. Dort sollen Optionen, Aufwand, Risiko, Nutzen und Empfehlung als lokales Schema ergänzt werden.
 
 Empfohlene Reihenfolge:
 
 ```text
-1. DiagCenter im Frontend sichtbar machen
-2. Decision Assistant ergänzen
-3. Private Project Manager ergänzen
-4. Release ZIP Workflow testen
-5. Installer Endanwender Test durchführen
+1. Decision Assistant ergänzen
+2. Private Project Manager ergänzen
+3. Release ZIP Workflow testen
+4. Installer Endanwender Test durchführen
+5. Health und Energy Radar ergänzen
 ```
 
 ## Pflege Ablauf

--- a/frontend/public/jarvis-diagcenter.html
+++ b/frontend/public/jarvis-diagcenter.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>JARVIS DiagCenter</title>
+<style>
+:root{--bg:#02040a;--cyan:#00d7ff;--green:#00ff95;--amber:#ffb84d;--red:#ff2838;--text:#e8fbff;--muted:rgba(220,248,255,.68);--line:rgba(0,215,255,.46)}
+*{box-sizing:border-box}html,body{margin:0;min-height:100%;background:#000;color:var(--text);font-family:Consolas,Menlo,Monaco,monospace}body{background:radial-gradient(circle at 50% 18%,rgba(0,126,180,.34),transparent 34%),radial-gradient(circle at 50% 70%,#061827,#01040a 62%,#000 100%)}body:before{content:"";position:fixed;inset:-20%;background-image:linear-gradient(rgba(0,215,255,.04) 1px,transparent 1px),linear-gradient(90deg,rgba(0,215,255,.035) 1px,transparent 1px);background-size:42px 42px;animation:grid 34s linear infinite;mask-image:radial-gradient(circle,#000 0 72%,transparent 100%);pointer-events:none}.wrap{position:relative;z-index:2;width:min(1400px,96vw);margin:0 auto;padding:18px}.frame{border:1px solid var(--line);min-height:calc(100vh - 36px);padding:18px;background:linear-gradient(180deg,rgba(4,24,43,.72),rgba(2,8,16,.56));box-shadow:inset 0 0 42px rgba(0,215,255,.09),0 0 35px rgba(0,115,255,.16)}.top{display:grid;grid-template-columns:1fr auto 1fr;gap:16px;align-items:start}.status{font-size:12px;color:var(--muted);letter-spacing:.08em}.status b{display:block;color:#fff;font-size:18px;margin-top:5px;text-shadow:0 0 12px var(--cyan)}h1{margin:0;text-align:center;font-size:clamp(36px,5vw,74px);font-weight:300;letter-spacing:.18em;line-height:.9;color:#fff;text-shadow:0 0 10px #fff,0 0 34px var(--cyan)}.subtitle{text-align:center;color:var(--muted);font-size:13px;letter-spacing:.18em;margin-top:12px}.right{text-align:right}.grid{display:grid;grid-template-columns:1fr 1.25fr 1fr;gap:14px;margin-top:22px}.panel{border:1px solid var(--line);background:linear-gradient(180deg,rgba(4,24,43,.78),rgba(2,8,16,.62));box-shadow:inset 0 0 18px rgba(0,215,255,.06),0 0 22px rgba(0,115,255,.1);padding:14px;position:relative;overflow:hidden}.panel:before{content:"";position:absolute;left:0;top:0;width:2px;height:100%;background:linear-gradient(var(--cyan),transparent,var(--red));opacity:.75}.panel h2,.panel h3{margin:0 0 12px;color:#fff;font-size:13px;letter-spacing:.1em;text-shadow:0 0 9px var(--cyan)}.summary{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:14px}.metric{text-align:center;border:1px solid rgba(0,215,255,.32);background:rgba(0,12,24,.42);padding:16px}.metric span{display:block;color:var(--muted);font-size:11px}.metric strong{display:block;color:#fff;font-size:32px;font-weight:300;text-shadow:0 0 13px var(--cyan);margin-top:5px}.checks{display:grid;gap:8px}.check{display:grid;grid-template-columns:1fr auto;gap:10px;align-items:center;border:1px solid rgba(0,215,255,.22);background:rgba(0,12,24,.34);padding:10px;color:var(--muted);font-size:12px}.check b{font-weight:400}.ok{color:var(--green)!important;text-shadow:0 0 8px rgba(0,255,149,.75)}.bad{color:var(--red)!important;text-shadow:0 0 8px rgba(255,40,56,.8)}.warn{color:var(--amber)!important}.source{margin-top:10px;color:rgba(220,248,255,.45);font-size:10px;letter-spacing:.08em}.raw{max-height:520px;overflow:auto;white-space:pre-wrap;border:1px solid rgba(0,215,255,.22);background:rgba(0,12,24,.34);padding:12px;color:var(--muted);font-size:11px;line-height:1.45}.actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:14px}.actions button,.home{color:#fff;text-decoration:none;border:1px solid var(--line);padding:9px 12px;background:rgba(0,12,24,.66);font-size:11px;letter-spacing:.08em;cursor:pointer}.actions button:hover,.home:hover{box-shadow:0 0 18px rgba(0,215,255,.24)}.home{position:fixed;left:20px;top:20px;z-index:5}.section-list{display:grid;gap:8px}.section-row{border:1px solid rgba(0,215,255,.22);background:rgba(0,12,24,.34);padding:10px;color:var(--muted);font-size:12px}.section-row strong{display:block;color:#fff;margin-bottom:5px}.footer{margin-top:14px;text-align:center;color:rgba(220,248,255,.5);font-size:11px;letter-spacing:.1em}@keyframes grid{to{transform:translate(42px,42px)}}@media(max-width:1000px){.top,.grid,.summary{grid-template-columns:1fr}.right{text-align:left}.wrap{padding:10px}.frame{min-height:calc(100vh - 20px)}}
+</style>
+</head>
+<body>
+<a class="home" href="../../index.html">BACK TO LAUNCHER</a>
+<div class="wrap"><div class="frame">
+<header class="top"><div class="status">DIAGNOSTIC MODE<b id="mode">CONNECTING</b></div><div><h1>DiagCenter</h1><div class="subtitle">LOCAL SYSTEM DIAGNOSTIC HUB</div></div><div class="status right">ENDPOINT<b>/diagnostic/center</b></div></header>
+<section class="summary"><div class="metric"><span>TOTAL CHECKS</span><strong id="total">0</strong></div><div class="metric"><span>OK</span><strong id="ok">0</strong></div><div class="metric"><span>FAILED</span><strong id="failed">0</strong></div></section>
+<section class="grid">
+<article class="panel"><h3>CHECKS</h3><div class="checks" id="checks"></div><div class="source" id="source">source: waiting</div></article>
+<article class="panel"><h2>DIAGNOSTIC SECTIONS</h2><div class="section-list" id="sections"></div></article>
+<article class="panel"><h3>RAW RESPONSE</h3><pre class="raw" id="raw">Warte auf Backend...</pre><div class="actions"><button onclick="loadDiag()">REFRESH</button><button onclick="copyRaw()">COPY JSON</button></div></article>
+</section>
+<div class="footer">JARVIS DIAGCENTER B6.6.18 FRONTEND BUILD</div>
+</div></div>
+<script>
+const endpoint='/diagnostic/center';
+const $=id=>document.getElementById(id);
+function statusClass(ok){return ok?'ok':'bad'}
+function safeJson(value){try{return JSON.stringify(value,null,2)}catch{return String(value)}}
+function sectionSummary(value){if(!value)return 'no data';if(Array.isArray(value))return `${value.length} items`;if(typeof value==='object'){const keys=Object.keys(value);if('ok'in value)return `ok: ${value.ok}`;if('status'in value)return `status: ${value.status}`;return keys.slice(0,6).join(', ')||'object'}return String(value)}
+async function loadDiag(){
+  $('mode').textContent='LOADING';
+  $('source').textContent='source: '+endpoint;
+  try{
+    const r=await fetch(endpoint,{cache:'no-store'});
+    if(!r.ok)throw new Error('HTTP '+r.status);
+    const data=await r.json();
+    const summary=data.summary||{};
+    $('total').textContent=summary.checks_total??(data.checks||[]).length??0;
+    $('ok').textContent=summary.checks_ok??0;
+    $('failed').textContent=summary.checks_failed??0;
+    $('mode').textContent=data.status==='ok'?'OK':'ATTENTION';
+    $('mode').className=data.status==='ok'?'ok':'warn';
+    $('checks').innerHTML=(data.checks||[]).map(c=>`<div class="check"><span>${c.name||'check'}</span><b class="${statusClass(!!c.ok)}">${c.ok?'OK':'FAIL'}</b></div>`).join('')||'<div class="check"><span>Keine Checks geliefert</span><b class="warn">WARN</b></div>';
+    const sections=data.sections||{};
+    $('sections').innerHTML=Object.entries(sections).map(([name,value])=>`<div class="section-row"><strong>${name}</strong><span>${sectionSummary(value)}</span></div>`).join('')||'<div class="section-row"><strong>Keine Sections</strong><span>Backend liefert keine Detaildaten</span></div>';
+    $('raw').textContent=safeJson(data);
+  }catch(e){
+    $('mode').textContent='OFFLINE';$('mode').className='bad';$('failed').textContent='1';$('checks').innerHTML=`<div class="check"><span>DiagCenter Backend</span><b class="bad">FAIL</b></div>`;$('sections').innerHTML='<div class="section-row"><strong>Fehler</strong><span>Backend nicht erreichbar oder Endpunkt fehlt</span></div>';$('raw').textContent=String(e);
+  }
+}
+async function copyRaw(){try{await navigator.clipboard.writeText($('raw').textContent||'')}catch{}}
+loadDiag();setInterval(loadDiag,15000);
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -9,10 +9,10 @@
     html,body{margin:0;width:100%;height:100%;background:#000814;color:#e8fbff;font-family:Consolas,Menlo,Monaco,monospace;overflow:hidden}
     body{display:grid;place-items:center;background:radial-gradient(circle at 50% 42%,rgba(0,126,180,.28),transparent 34%),radial-gradient(circle,#061827,#01040a 62%,#000 100%)}
     body:before{content:"";position:fixed;inset:-20%;background-image:linear-gradient(rgba(0,212,255,.045) 1px,transparent 1px),linear-gradient(90deg,rgba(0,212,255,.035) 1px,transparent 1px);background-size:42px 42px;animation:grid 34s linear infinite;mask-image:radial-gradient(circle,#000 0 70%,transparent 100%)}
-    main{position:relative;z-index:2;width:min(920px,92vw);border:1px solid rgba(0,212,255,.48);padding:34px;background:linear-gradient(180deg,rgba(4,24,43,.78),rgba(2,8,16,.62));box-shadow:inset 0 0 32px rgba(0,212,255,.08),0 0 40px rgba(0,128,255,.16)}
+    main{position:relative;z-index:2;width:min(1180px,92vw);border:1px solid rgba(0,212,255,.48);padding:34px;background:linear-gradient(180deg,rgba(4,24,43,.78),rgba(2,8,16,.62));box-shadow:inset 0 0 32px rgba(0,212,255,.08),0 0 40px rgba(0,128,255,.16)}
     h1{margin:0 0 10px;text-align:center;font-weight:300;letter-spacing:.22em;font-size:clamp(38px,7vw,72px);text-shadow:0 0 12px #fff,0 0 34px #00d4ff}
     p{text-align:center;color:rgba(220,248,255,.7);margin:0 0 28px;font-size:13px;letter-spacing:.08em}
-    .links{display:grid;grid-template-columns:repeat(3,1fr);gap:16px}
+    .links{display:grid;grid-template-columns:repeat(4,1fr);gap:16px}
     a{display:block;border:1px solid rgba(0,212,255,.5);padding:18px;text-align:center;color:#fff;text-decoration:none;background:rgba(0,16,30,.55);box-shadow:inset 0 0 18px rgba(0,212,255,.06);transition:.18s}
     a:hover{transform:translateY(-2px);box-shadow:0 0 28px rgba(0,212,255,.22)}
     a strong{display:block;font-size:18px;letter-spacing:.12em;text-shadow:0 0 12px #00d4ff}
@@ -21,7 +21,10 @@
     a.ultron{border-color:rgba(255,40,56,.55)}
     a.life strong{text-shadow:0 0 12px #ffb84d}
     a.life{border-color:rgba(255,184,77,.55)}
+    a.diag strong{text-shadow:0 0 12px #00ff95}
+    a.diag{border-color:rgba(0,255,149,.55)}
     @keyframes grid{to{transform:translate(42px,42px)}}
+    @media(max-width:1100px){.links{grid-template-columns:repeat(2,1fr)}}
     @media(max-width:900px){.links{grid-template-columns:1fr}main{padding:24px}html,body{overflow:auto}}
   </style>
 </head>
@@ -33,6 +36,7 @@
       <a href="frontend/public/jarvis-global-overview-standalone.html"><strong>GLOBAL OVERVIEW</strong><span>bestehende stabile Weltkarten Ansicht</span></a>
       <a class="ultron" href="frontend/public/jarvis-ultron-command-grid.html"><strong>ULTRON GRID</strong><span>neue JARVIS und ULTRON Ansicht mit Modus Umschaltung</span></a>
       <a class="life" href="frontend/public/jarvis-lifeos-command-center.html"><strong>LIFEOS</strong><span>Daily Briefing und persönlicher Operations Layer</span></a>
+      <a class="diag" href="frontend/public/jarvis-diagcenter.html"><strong>DIAGCENTER</strong><span>lokale Diagnose Übersicht für Backend, Ports, Logs und Runtime</span></a>
     </div>
   </main>
 </body>


### PR DESCRIPTION
## Beschreibung

Ergänzt eine lokale DiagCenter HUD Seite und verlinkt sie im Launcher.

## Änderungen

- Neue Seite `frontend/public/jarvis-diagcenter.html`
- Launcher um `DIAGCENTER` Einstieg erweitert
- DiagCenter Frontend ruft `GET /diagnostic/center` ab
- Anzeige für Checks, Sections und Raw JSON
- Refresh Button und Copy JSON Button
- Changelog Eintrag `B6.6.18`
- PROJECT_STATUS.md gemäß Pflege Regel aktualisiert

## Warum

DiagCenter war bisher nur als Backend Sammel Endpunkt vorhanden. Mit dieser Änderung wird die Diagnose sichtbar und bedienbar, ohne direkt die große React App anzufassen.

## Hinweis

Die Seite funktioniert sinnvoll, wenn das Backend unter `http://127.0.0.1:8000` läuft und die Seite über JARVIS beziehungsweise den lokalen Server geladen wird.

## Sicherheit

- keine externen Assets
- keine Telemetrie
- keine privaten Daten
- nur lokale Diagnoseanzeige