### PR TITLE
feat(frontend): master HUD tokens layer (Track A)

### DIFF
--- a/docs/FRONTEND_VISUAL_ROADMAP.md
+++ b/docs/FRONTEND_VISUAL_ROADMAP.md
@@ -1,0 +1,106 @@
+# Frontend Visual Roadmap
+
+> Ziel: Das echte App-Frontend (`frontend/src/`) auf das gleiche visuelle Niveau heben wie das HUD-Dashboard (`docs/index.html`) — **ohne** die fragile Logik (Orb, SSE-Parser, Voice, LocalStorage) anzufassen.
+
+**Branding-Anker:** HUD-Style · Cyan / Anthrazit · Operator-Console · industrial-serious, kein Marvel-Cosplay.
+**Master-Referenz:** [`docs/index.html`](index.html) und [`docs/assets/jarvis-hero.svg`](assets/jarvis-hero.svg).
+
+---
+
+## Ground Truth (Stand 2026-05)
+
+| Bereich | Ist-Zustand |
+|---|---|
+| Routing | Kein React Router — `App.tsx` ist 905 Zeilen, `activeNav`-State switched ~31 Pages |
+| Pages | 31 `*Page.tsx` Components in `frontend/src/components/` |
+| Styling | Vanilla CSS, 16 Files. **Zwei parallele Token-Sets**: `--jv-*` (App.css), `--panel/--cyan` (jarvis-dashboard.css) → Palette-Drift |
+| Themes | 3 Varianten via `data-jarvisTheme`: `jarvis`, `matrix`, `ultron` |
+| Build | Vite 5, base `./` (Electron-relative), Three.js Dependency |
+| Sound-Engine | Custom `jarvisSound`, fragil — nicht anfassen |
+| Backend-Coupling | SSE-Stream-Parser in `App.tsx::sendMessage()` — nicht anfassen |
+
+## Master-Palette (verbindlich)
+
+| Variable | Hex | Verwendung |
+|---|---|---|
+| `--jv-bg-0` | `#05080d` | tiefster Hintergrund |
+| `--jv-bg-1` | `#0a0e14` | Panel-Hintergrund |
+| `--jv-bg-2` | `#0f141c` | erhöhte Karten |
+| `--jv-bg-3` | `#161c27` | Hover/Active |
+| `--jv-line` | `#1f2937` | Standard-Border |
+| `--jv-line-soft` | `#141b25` | sanfte Trennlinien |
+| `--jv-text` | `#e6f1ff` | Primärtext |
+| `--jv-text-dim` | `#8aa1bd` | Sekundärtext |
+| `--jv-text-mute` | `#5b6b82` | Labels, Hints |
+| `--jv-cyan` | `#00d4ff` | Primary / Brand |
+| `--jv-cyan-dim` | `#0a7c94` | Cyan-Borders |
+| `--jv-green` | `#00ff88` | OK / Online |
+| `--jv-amber` | `#ffb800` | Warning / RiskLevel MED |
+| `--jv-red` | `#ff3b5c` | Error / RiskLevel HIGH / Mic-OFF |
+| `--jv-violet` | `#b48cff` | Audit / Storage |
+
+---
+
+## Tracks
+
+### 🟢 Track A — Tokens-Layer angleichen
+**Risiko:** keins. **Aufwand:** ~2h. **Sichtbarkeit:** sofort.
+
+- Neues File: `frontend/src/styles/tokens.css`
+- Master-Palette als Single Source of Truth (siehe Tabelle oben)
+- Bestehende `--jv-*` und `--panel/--cyan/...` zeigen **referenziell** auf die Master-Vars
+- Import in `frontend/src/main.tsx` als erste CSS-Datei
+- Keine Component-Änderungen, keine Layout-Änderungen
+- **Akzeptanz:** App startet, alle Pages rendern, Farben matchen jetzt das Pages-Dashboard
+
+### 🟡 Track B — Topbar + Sidebar polish
+**Risiko:** low. **Aufwand:** ~3h. **Sichtbarkeit:** hoch.
+
+- Topbar bekommt persistent **`MIC OFF`-Indicator** (rote Pille) → Datenschutz-Versprechen sichtbar einlösen
+- Sidebar bekommt **Pulse-Dots** für aktive Modul-Status (Pure CSS, dataset-driven)
+- Risk-Indicator-Klassen für Buttons mit hohem RiskLevel (`data-risk="high"`)
+- Glow-States für aktiven Nav-Eintrag
+- **Pure CSS**, kein React-State
+- **Akzeptanz:** App.tsx-Logik unverändert, aber Topbar/Sidebar matchen das Dashboard-Look
+
+### 🟠 Track C — HUD-Frame: Mockup → Live
+**Risiko:** medium. **Aufwand:** ~4h.
+
+- `JarvisHudFrame.tsx` empfängt schon Props (`memoryCount`, `messageCount`, `awarenessOnline`) die nicht genutzt werden
+- Conversation Context Card: aktuelle Session anstelle Hardcoded
+- System Snapshot: echte Telemetrie-Werte statt Mock
+- Quick Actions: bleiben statisch (keine Logik-Änderung)
+- **Akzeptanz:** Cards zeigen Live-Daten, keine neuen Backend-Calls
+
+### 🔵 Track D — Command Palette `Strg+K` (optional)
+**Risiko:** low (additive). **Aufwand:** ~3h.
+- Neues Component: `CommandPalette.tsx`
+- Listet alle 31 Pages plus häufige Aktionen
+- Keyboard-First — typisch JARVIS-USP
+- **Akzeptanz:** `Strg+K` öffnet Palette, Enter springt zu Page
+
+### 🟣 Track E — Empty States mit Charakter (optional)
+**Risiko:** keins. **Aufwand:** ~2h.
+- Pages wie `KnowledgePage`, `FilesPage`, `AuditLogPage` zeigen aktuell vermutlich generische "Keine Daten" Texte
+- Pro Page ein passendes SVG + sinnvoller Primary CTA
+- **Akzeptanz:** keine "No data" Strings mehr
+
+---
+
+## Tabu — niemals anfassen ohne separate Diskussion
+
+- `Orb.tsx` (Three.js, hand-getuned)
+- `App.tsx::sendMessage()` und der gesamte SSE-Parser
+- `sound-engine` Imports
+- Voice / Speech Recognition Setup
+- LocalStorage-Keys (Zoom, Theme, SafeMode)
+
+---
+
+## Lieferung
+
+- Ein Track = ein PR
+- Branch-Naming: `feat/frontend-track-{a|b|c|d|e}-…`
+- Vor jedem Track: dieses Roadmap-Dokument als Prompt-Anker referenzieren
+- Nach jedem Track: User entscheidet ob nächster Track freigegeben wird
+- Tabu-Sektion ist verbindlich

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,9 @@ import { jarvisSound } from "./sound-engine";
 import "./jarvis-dashboard.css";
 import "./orb-legacy.css";
 import "./chat-window.css";
+// Master HUD tokens — must load LAST so the alias layer overrides the legacy
+// drift values still embedded in jarvis-dashboard.css. See docs/FRONTEND_VISUAL_ROADMAP.md.
+import "./styles/tokens.css";
 
 type Role = "operator" | "jarvis";
 type Level = "ok" | "warn" | "critical" | "unknown";

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -1,0 +1,105 @@
+/* ============================================================================
+ * JARVIS · Frontend Design Tokens
+ * ----------------------------------------------------------------------------
+ * Single source of truth for the operator-console palette.
+ * Mirrors docs/index.html (the HUD dashboard) and jarvis/_ui.py (the CLI),
+ * so the live frontend, the GitHub Pages dashboard, and the CLI all share
+ * the exact same colors.
+ *
+ * Import order: must load AFTER jarvis-dashboard.css so the legacy --jv-*
+ * aliases at the bottom of this file win over the older drift values.
+ *
+ * Do not put component-specific styles here. Tokens only.
+ * ========================================================================= */
+
+:root {
+  /* ---------- surfaces ---------- */
+  --j-bg-0: #05080d;             /* deepest background, voids around panels */
+  --j-bg-1: #0a0e14;             /* primary panel background */
+  --j-bg-2: #0f141c;             /* elevated card background */
+  --j-bg-3: #161c27;             /* hover / active card */
+  --j-line: #1f2937;             /* default border */
+  --j-line-soft: #141b25;        /* divider lines, dashed separators */
+
+  /* ---------- text ---------- */
+  --j-text:      #e6f1ff;        /* primary text */
+  --j-text-dim:  #8aa1bd;        /* secondary text, table cells */
+  --j-text-mute: #5b6b82;        /* labels, hints, captions */
+
+  /* ---------- brand & semantic ---------- */
+  --j-cyan:      #00d4ff;        /* primary brand, links, focus */
+  --j-cyan-dim:  #0a7c94;        /* cyan border accents */
+  --j-green:     #00ff88;        /* OK, online, low risk */
+  --j-amber:     #ffb800;        /* warning, medium risk, pending */
+  --j-red:       #ff3b5c;        /* error, high risk, mic-off */
+  --j-violet:    #b48cff;        /* audit log, persistent storage */
+
+  /* ---------- glow / accent helpers ---------- */
+  --j-cyan-glow:  0 0 12px rgba(0, 212, 255, 0.45);
+  --j-cyan-glow-soft: 0 0 6px rgba(0, 212, 255, 0.25);
+  --j-green-glow: 0 0 10px rgba(0, 255, 136, 0.45);
+  --j-amber-glow: 0 0 10px rgba(255, 184, 0, 0.40);
+  --j-red-glow:   0 0 10px rgba(255, 59, 92, 0.45);
+
+  /* ---------- elevation ---------- */
+  --j-shadow-card: 0 0 0 1px var(--j-line) inset, 0 8px 32px rgba(0, 0, 0, 0.5);
+  --j-shadow-soft: 0 4px 18px rgba(0, 0, 0, 0.35);
+
+  /* ---------- typography ---------- */
+  --j-font-mono: "JetBrains Mono", "SF Mono", "Cascadia Code", Consolas, monospace;
+  --j-font-sans: "Inter", "Segoe UI", system-ui, -apple-system, Arial, sans-serif;
+  --j-font-display: "Orbitron", "Inter", system-ui, sans-serif;
+
+  /* ---------- spacing scale (4px base) ---------- */
+  --j-space-1: 4px;
+  --j-space-2: 8px;
+  --j-space-3: 12px;
+  --j-space-4: 16px;
+  --j-space-5: 20px;
+  --j-space-6: 24px;
+  --j-space-8: 32px;
+
+  /* ---------- radius ---------- */
+  --j-radius-sm: 4px;
+  --j-radius-md: 8px;
+  --j-radius-lg: 12px;
+  --j-radius-pill: 999px;
+
+  /* ---------- motion ---------- */
+  --j-ease: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --j-dur-fast: 0.15s;
+  --j-dur-base: 0.25s;
+  --j-dur-slow: 0.45s;
+
+  /* ---------- z-index scale ---------- */
+  --j-z-base: 1;
+  --j-z-overlay: 50;
+  --j-z-modal: 100;
+  --j-z-toast: 200;
+  --j-z-boot: 999;
+}
+
+/* ============================================================================
+ * Legacy alias layer
+ * ----------------------------------------------------------------------------
+ * The existing CSS files (App.css, jarvis-dashboard.css) still reference
+ * --jv-* variables. We keep those names working but re-point them at the
+ * master tokens above. This kills the palette drift between the two files
+ * without touching a single component.
+ *
+ * Existing component CSS continues to use --jv-* — no migration required.
+ * ========================================================================= */
+
+:root {
+  --jv-bg:            var(--j-bg-1);
+  --jv-bg-deep:       var(--j-bg-0);
+  --jv-panel:         rgba(15, 20, 28, 0.72);     /* var(--j-bg-2) at 72% */
+  --jv-panel-strong:  rgba(15, 20, 28, 0.88);
+  --jv-border:        rgba(0, 212, 255, 0.20);    /* var(--j-cyan) at 20% */
+  --jv-border-strong: var(--j-cyan);
+  --jv-text:          var(--j-text);
+  --jv-text-dim:      var(--j-text-dim);
+  --jv-text-sec:      var(--j-text-mute);
+  --jv-accent:        var(--j-cyan);
+  --jv-accent-glow:   rgba(0, 212, 255, 0.55);
+}


### PR DESCRIPTION
## Summary

**Track A** der [Frontend Visual Roadmap](docs/FRONTEND_VISUAL_ROADMAP.md). Bringt die Frontend-Farben in Deckung mit dem HUD-Dashboard (\`docs/index.html\`) und der CLI (\`jarvis/_ui.py\`) — eine einzige Master-Palette für alle drei Surfaces.

## Was geändert wird

### Neu
- **\`frontend/src/styles/tokens.css\`** — Master-Tokens (\`--j-*\`) für:
  - Surfaces (\`--j-bg-0\` bis \`--j-bg-3\`, Lines)
  - Text (primary / dim / mute)
  - Brand & Semantic (\`--j-cyan\`, \`--j-green\`, \`--j-amber\`, \`--j-red\`, \`--j-violet\`)
  - Glow-Shadows (\`--j-cyan-glow\` etc.)
  - Typography (Mono / Sans / Display Stacks)
  - Spacing-Skala (4px Base)
  - Radius, Motion, Z-Index
  - **Legacy Alias-Block** — \`--jv-*\` zeigen jetzt auf Master-Tokens
- **\`docs/FRONTEND_VISUAL_ROADMAP.md\`** — Plan für Tracks A → E mit Tabu-Sektion (Orb, SSE-Parser, Sound)

### Geändert
- **\`frontend/src/App.tsx\`** — eine Import-Zeile: \`import \"./styles/tokens.css\"\` als letztes CSS, damit der Alias-Layer im Cascade gewinnt

### **NICHT geändert**
- Kein Component, keine \`*Page.tsx\`, kein State, keine Logik
- \`jarvis-dashboard.css\` unangetastet (minified, fragile)
- \`Orb.tsx\`, SSE-Parser, sound-engine — Tabu-Liste eingehalten

## Effekt

Vorher: \`--jv-bg\` war \`#03060d\` (jarvis-dashboard.css) bzw. \`#050508\` (App.css, nicht mehr importiert) → palette drift.
Nachher: \`--jv-bg\` zeigt auf \`--j-bg-1\` = \`#0a0e14\` — **identisch zum Pages-Dashboard**.

Gleiches Prinzip für \`--jv-accent\` (jetzt \`#00d4ff\`), \`--jv-text\`, etc.

## Migration für künftige Components

Bestehende Components müssen **nichts** migrieren — der Alias-Layer hält \`--jv-*\` lebendig. Neue Components sollen direkt die Master-Tokens nutzen:

\`\`\`css
.my-card {
  background: var(--j-bg-2);
  border: 1px solid var(--j-line);
  color: var(--j-text);
  box-shadow: var(--j-shadow-card);
}
\`\`\`

## Test plan

- [x] \`npm run typecheck\` — passes
- [x] \`npm run build\` — passes (95.87 kB CSS, 622 kB JS, no new warnings)
- [ ] \`npm run dev\` lokal → manuell durchklicken: alle 31 Pages rendern, Cyan-Akzente sichtbar konsistent
- [ ] Theme-Switching (jarvis / matrix / ultron) funktioniert weiterhin

## Folge-PRs (gemäß Roadmap)

- **Track B** — Topbar/Sidebar polish (MIC-OFF-Pille, Pulse-Dots, Risk-Indicators)
- **Track C** — HUD-Frame Cards live binden statt Mock
- **Track D** — Command Palette \`Strg+K\`
- **Track E** — Empty States mit Charakter

🤖 Generated with [Claude Code](https://claude.com/claude-code)