### PR TITLE
chore: release hygiene for B6.6.36

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jarvis-windows-standalone",
-  "version": "B6.6.30",
+  "version": "B6.6.36",
   "description": "JARVIS Windows Standalone - local first HUD, LifeOS, DiagCenter, release installer and automation audit frontend",
   "main": "electron/main.js",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jarvis-windows-standalone"
-version = "6.5.1"
+version = "6.6.36"
 description = "Local first Windows standalone assistant for electrical work planning"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/scripts/dev/START_JARVIS.ps1
+++ b/scripts/dev/START_JARVIS.ps1
@@ -17,4 +17,6 @@ Invoke-JarvisCoreScript `
   -BoundParameters $bound `
   -LiteralReplacements @{
     'Join-Path $Root "FIRST_SETUP.ps1"' = 'Join-Path $Root "scripts\install\FIRST_SETUP.ps1"'
+    '"JARVIS_GITHUB_OWNER","JARVIS_GITHUB_REPO","JARVIS_GITHUB_TOKEN"' = '"JARVIS_GITHUB_OWNER","JARVIS_GITHUB_REPO"'
+    'Setze JARVIS_GITHUB_OWNER, JARVIS_GITHUB_REPO und JARVIS_GITHUB_TOKEN als User-Env, um Auto-Update zu aktivieren.' = 'Setze mindestens JARVIS_GITHUB_OWNER und JARVIS_GITHUB_REPO als User-Env, um Auto-Update zu aktivieren. JARVIS_GITHUB_TOKEN ist nur fuer private Repos oder hoehere API Limits noetig.'
   }

--- a/scripts/install/JARVIS_INSTALL_CONFIG.json
+++ b/scripts/install/JARVIS_INSTALL_CONFIG.json
@@ -1,6 +1,6 @@
 {
   "app_name": "JARVIS Windows Standalone",
-  "version": "B6.5.1",
+  "version": "B6.6.36",
   "default_install_dir": "%LOCALAPPDATA%\\JARVIS_WINDOWS_STANDALONE",
   "model": "qwen3:8b",
   "winget_dependencies": [
@@ -27,7 +27,7 @@
     "Bestehende Installationen werden vor Clean Install in ein Backupverzeichnis verschoben."
   ],
   "productization": {
-    "update_system": "local staged zip with plan and product installer",
+    "update_system": "GitHub Release ZIP staging with optional token and product installer apply",
     "installer_modes": [
       "Install",
       "Repair",
@@ -51,15 +51,19 @@
       "EXPORT_JARVIS_DATA.bat"
     ]
   },
-  "private_github_updates": {
-    "mode": "private_github_release",
+  "github_updates": {
+    "mode": "github_release",
     "required_environment": [
       "JARVIS_GITHUB_OWNER",
-      "JARVIS_GITHUB_REPO",
-      "JARVIS_GITHUB_TOKEN"
+      "JARVIS_GITHUB_REPO"
+    ],
+    "optional_environment": [
+      "JARVIS_GITHUB_TOKEN",
+      "JARVIS_GITHUB_RELEASE",
+      "JARVIS_GITHUB_PACKAGE_ASSET"
     ],
     "package_asset": "Release ZIP asset, usually JARVIS_Bx_y_PRODUCTION_INSTALLER.zip",
-    "token_rule": "Token is read from the local environment and must never be committed into this package."
+    "token_rule": "Token is optional for public repositories and required only for private repositories or higher API limits. It is read from the local environment and must never be committed into this package."
   },
   "production_installer": {
     "execution_policy_bypass": true,
@@ -94,9 +98,9 @@
     "fix": "ProcessStartInfo.ArgumentList removed for Windows PowerShell compatibility; uses ProcessStartInfo.Arguments with explicit quoting",
     "affected": [
       "FIRST_SETUP.ps1",
+      "REPAIR.ps1",
       "INSTALL_JARVIS.ps1",
-      "START_JARVIS.ps1",
-      "REPAIR.ps1"
+      "START_JARVIS.ps1"
     ]
   },
   "installer_hotfix_3": {
@@ -121,7 +125,11 @@
     "reason": "winget can emit non-fatal stderr/progress output; installer should fail only on native ExitCode."
   },
   "installer_hotfix_7": {
-    "fix": "Added CHECK_GITHUB_UPDATE.ps1/.bat for private GitHub Release download, staging and optional PRODUCT_INSTALLER update apply.",
-    "reason": "Installed systems need a stable local bootstrapper that can fetch the latest private release without storing tokens in the package."
+    "fix": "Added CHECK_GITHUB_UPDATE.ps1/.bat for GitHub Release download, staging and optional PRODUCT_INSTALLER update apply.",
+    "reason": "Installed systems need a stable local bootstrapper that can fetch the latest release without storing tokens in the package."
+  },
+  "installer_hotfix_8": {
+    "fix": "GitHub release updates now support public repositories without JARVIS_GITHUB_TOKEN. Token remains optional for private repositories and higher API limits.",
+    "reason": "The public xpozer/jarvis-windows-standalone release flow should not require every user to create a GitHub token."
   }
 }

--- a/scripts/maintenance/CHECK_GITHUB_UPDATE.core.ps1
+++ b/scripts/maintenance/CHECK_GITHUB_UPDATE.core.ps1
@@ -23,15 +23,33 @@ function Log($Level, $Message){
 
 function Fail($Message){ Log "ERROR" $Message; throw $Message }
 
-function Require-Env($Name){
+function Get-EnvValue($Name){
   $value = [Environment]::GetEnvironmentVariable($Name, "Process")
   if([string]::IsNullOrWhiteSpace($value)){
     $value = [Environment]::GetEnvironmentVariable($Name, "User")
   }
+  if([string]::IsNullOrWhiteSpace($value)){ return "" }
+  return $value.Trim()
+}
+
+function Require-Env($Name){
+  $value = Get-EnvValue $Name
   if([string]::IsNullOrWhiteSpace($value)){
     Fail "$Name fehlt. Bitte als Umgebungsvariable setzen."
   }
-  return $value.Trim()
+  return $value
+}
+
+function New-GitHubHeaders([string]$Token, [string]$Accept){
+  $headers = @{
+    "Accept" = $Accept
+    "X-GitHub-Api-Version" = "2022-11-28"
+    "User-Agent" = "JARVIS-Windows-Standalone-Updater"
+  }
+  if(-not [string]::IsNullOrWhiteSpace($Token)){
+    $headers["Authorization"] = "Bearer $Token"
+  }
+  return $headers
 }
 
 function Get-LocalVersion {
@@ -58,10 +76,10 @@ function Test-JarvisZip($ZipPath){
 
 $owner = Require-Env "JARVIS_GITHUB_OWNER"
 $repo = Require-Env "JARVIS_GITHUB_REPO"
-$token = Require-Env "JARVIS_GITHUB_TOKEN"
-$release = [Environment]::GetEnvironmentVariable("JARVIS_GITHUB_RELEASE", "Process")
+$token = Get-EnvValue "JARVIS_GITHUB_TOKEN"
+$release = Get-EnvValue "JARVIS_GITHUB_RELEASE"
 if([string]::IsNullOrWhiteSpace($release)){ $release = "latest" }
-$assetName = [Environment]::GetEnvironmentVariable("JARVIS_GITHUB_PACKAGE_ASSET", "Process")
+$assetName = Get-EnvValue "JARVIS_GITHUB_PACKAGE_ASSET"
 
 $releaseUrl = if($release -eq "latest"){
   "https://api.github.com/repos/$owner/$repo/releases/latest"
@@ -69,14 +87,10 @@ $releaseUrl = if($release -eq "latest"){
   "https://api.github.com/repos/$owner/$repo/releases/tags/$release"
 }
 
-$headers = @{
-  "Accept" = "application/vnd.github+json"
-  "Authorization" = "Bearer $token"
-  "X-GitHub-Api-Version" = "2022-11-28"
-  "User-Agent" = "JARVIS-Windows-Standalone-Updater"
-}
+$headers = New-GitHubHeaders -Token $token -Accept "application/vnd.github+json"
+$authMode = if([string]::IsNullOrWhiteSpace($token)){ "public" } else { "token" }
 
-Log "STEP" "Pruefe privates GitHub Release: $owner/$repo ($release)"
+Log "STEP" "Pruefe GitHub Release: $owner/$repo ($release, auth: $authMode)"
 $remote = Invoke-RestMethod -Uri $releaseUrl -Headers $headers -TimeoutSec 30
 $remoteVersion = [string]$remote.tag_name
 $localVersion = [string](Get-LocalVersion)
@@ -99,18 +113,22 @@ if($assetName){
 $safeName = ([string]$asset.name) -replace '[^a-zA-Z0-9._-]', '_'
 $target = Join-Path $Staging ((Get-Date -Format "yyyyMMdd_HHmmss") + "_" + $safeName)
 Log "STEP" "Lade Update ZIP: $($asset.name)"
-Invoke-WebRequest -Uri $asset.url -Headers @{
-  "Accept" = "application/octet-stream"
-  "Authorization" = "Bearer $token"
-  "X-GitHub-Api-Version" = "2022-11-28"
-  "User-Agent" = "JARVIS-Windows-Standalone-Updater"
-} -OutFile $target -TimeoutSec 120
+
+$downloadHeaders = New-GitHubHeaders -Token $token -Accept "application/octet-stream"
+$downloadUri = if([string]::IsNullOrWhiteSpace($token) -and $asset.browser_download_url){
+  [string]$asset.browser_download_url
+} else {
+  [string]$asset.url
+}
+
+Invoke-WebRequest -Uri $downloadUri -Headers $downloadHeaders -OutFile $target -TimeoutSec 120
 
 if(-not (Test-JarvisZip $target)){ Fail "Geladenes ZIP hat keine gueltige JARVIS Struktur: $target" }
 
 $manifest = @{
   staged_at = (Get-Date).ToString("s")
-  source = "private_github_release"
+  source = "github_release"
+  auth = $authMode
   release = $remoteVersion
   filename = $asset.name
   path = $target


### PR DESCRIPTION
## Summary

Kleiner Release Hygiene Schnitt fuer B6.6.36. Ziel ist weniger Versionsdrift und ein nutzerfreundlicheres Auto Update Verhalten.

## Geaendert

- `START_JARVIS` verlangt fuer Auto Update nur noch `JARVIS_GITHUB_OWNER` und `JARVIS_GITHUB_REPO`.
- `JARVIS_GITHUB_TOKEN` ist nur noch optional fuer private Repos oder hoehere GitHub API Limits.
- `CHECK_GITHUB_UPDATE.core.ps1` kann oeffentliche GitHub Release ZIPs ohne Token laden.
- Bei vorhandenem Token bleibt der private/API Asset Download weiter moeglich.
- `frontend/package.json` auf `B6.6.36` angehoben.
- `pyproject.toml` auf `6.6.36` angehoben.
- `scripts/install/JARVIS_INSTALL_CONFIG.json` auf `B6.6.36` angehoben und Update Metadata von private only auf public friendly GitHub Releases umgestellt.

## Warum

Das Repo ist oeffentlich. Normale Nutzer sollten fuer Updates keinen GitHub Token anlegen muessen. Der Token bleibt trotzdem moeglich, wenn spaeter private Releases oder Rate Limit Themen relevant werden.

## Test plan

Manuell auf Windows pruefen:

```powershell
$env:JARVIS_GITHUB_OWNER="xpozer"
$env:JARVIS_GITHUB_REPO="jarvis-windows-standalone"
$env:JARVIS_SKIP_UPDATE="0"
.\START_JARVIS.bat
```

Zusaetzlich mit Token pruefen:

```powershell
$env:JARVIS_GITHUB_TOKEN="<token>"
.\START_JARVIS.bat
```

Frontend Lockfile lokal nachziehen:

```powershell
cd frontend
npm install --package-lock-only
npm run typecheck
npm run build
```

Backend Checks:

```powershell
ruff check .
black --check .
pytest
```

## Bewusst nicht enthalten

- Keine UI Aenderung
- Kein Backend Refactor
- Kein direktes Update von `package-lock.json`, weil das lokal reproduzierbar mit npm geschrieben werden soll
- README und PROJECT_STATUS sollten nach erfolgreichem Windows Test mit dem finalen Release Tag nachgezogen werden
