### PR TITLE
feat(frontend): v18 F1 foundation shell

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -1,0 +1,104 @@
+# Frontend Changelog
+
+## v18_F1_FOUNDATION
+
+### Added
+
+- New Iron Man suit interface foundation shell.
+- Fullscreen fixed layout with three visible screen groups:
+  - centered Orb slot
+  - bottom command dialog
+  - four HUD corner placeholders
+- CommandBus foundation with register, parse, execute and getSuggestions.
+- Slash command registry with F1 stubs:
+  - /help
+  - /clear
+  - /agents
+  - /tools
+  - /audit
+  - /diag
+  - /settings
+  - /sap
+  - /vde
+  - /knowledge
+  - /work
+- Zustand UI store for focus, overlay and command history state.
+- Zustand Orb store for idle, listening, thinking, speaking and error placeholder states.
+- Global hotkeys:
+  - Ctrl K or Cmd K focuses command input
+  - ESC blurs input and closes overlay state
+- WebSocketClient placeholder prepared for later channels:
+  - /telemetry
+  - /audit
+  - /orb-state
+- Tailwind config foundation for later utility based UI work.
+
+### Changed
+
+- `frontend/index.html` stripped to one React entrypoint.
+- `frontend/src/main.tsx` stripped to direct RootLayout mount.
+- Runtime entry no longer mounts the legacy topbar, sidebar, tab navigation or old page shell.
+- `frontend/package.json` renamed version to `v18_F1_FOUNDATION`.
+- Added `zustand`, `tailwindcss`, `postcss` and `autoprefixer` for the v18 stack foundation.
+
+### Removed from runtime path
+
+The following legacy UI elements are no longer imported by the new runtime entry:
+
+- Legacy App shell
+- Topbar
+- Sidebar navigation
+- Tab navigation
+- Old dashboard visible page shell
+- Boot iframe overlay
+- Legacy bridge script tags from index.html
+
+### Planned physical delete after green build
+
+These files should be physically removed after local `npm run typecheck` confirms there are no lingering imports:
+
+- `frontend/src/App.tsx`
+  - Reason: old monolithic UI shell with visible menus, topbar, sidebar, page routing and legacy chat logic.
+- `frontend/src/jarvis-dashboard.css`
+  - Reason: old dashboard shell styling, not used by v18 RootLayout.
+- `frontend/src/orb-legacy.css`
+  - Reason: old Orb styling, F2 will bring the migrated Orb component cleanly.
+- `frontend/src/chat-window.css`
+  - Reason: old chat and panel styling, replaced by DialogSlot in F1.
+- Legacy page and sidebar components under `frontend/src/components/` that are only referenced by the old `App.tsx`.
+  - Reason: no visible menus, tabs or sidebars are allowed in v18.
+
+### Kept unchanged
+
+- Backend code
+- Python package config
+- Installer scripts
+- `docs/index.html`, because the existing GitHub Pages Orb is the source for F2 migration
+- Existing diagnostic HTML files
+- Existing local config and runtime data rules
+
+### Test checklist
+
+- [ ] `npm install` runs successfully
+- [ ] `npm run dev` starts without errors
+- [ ] Black fullscreen screen with vignette is visible
+- [ ] Orb placeholder is centered and pulses
+- [ ] Dialog is bottom centered and focusable with Ctrl K or Cmd K
+- [ ] Typing `/` opens suggestions
+- [ ] Enter on slash command logs `[JARVIS:F1:COMMAND]` in console
+- [ ] ESC blurs dialog
+- [ ] Arrow up and down navigate suggestions and history
+- [ ] Four HUD corner placeholders are visible
+- [ ] No old menus, tabs or sidebars are visible in runtime DOM
+- [ ] Mobile width around 375px does not break layout
+
+### ZIP build
+
+```powershell
+cd frontend
+npm install
+npm run typecheck
+npm run build
+New-Item -ItemType Directory -Force -Path ..\release | Out-Null
+Compress-Archive -Path .\* -DestinationPath ..\release\jarvis-v18_F1_FOUNDATION-frontend.zip -Force
+```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,53 @@
+# JARVIS v18_F1_FOUNDATION
+
+F1 ist der Strip und Foundation Block fuer das neue Iron Man Anzug Interface.
+
+## Setup
+
+```powershell
+cd frontend
+npm install
+npm run dev
+```
+
+Danach im Browser oeffnen:
+
+```text
+http://127.0.0.1:5173
+```
+
+## Build
+
+```powershell
+cd frontend
+npm run typecheck
+npm run build
+```
+
+## ZIP Build
+
+```powershell
+cd frontend
+npm install
+npm run typecheck
+npm run build
+Compress-Archive -Path .\* -DestinationPath ..\release\jarvis-v18_F1_FOUNDATION-frontend.zip -Force
+```
+
+## Verhalten in F1
+
+- Schwarzer Fullscreen ohne Scroll
+- Zentrierter Orb Platzhalter
+- Dialogfeld unten mit Slash Command Suggestions
+- Vier HUD Corner Platzhalter
+- Command Bus mit F1 Stub Commands
+- Strg K oder Cmd K fokussiert Eingabe
+- ESC blurrt Eingabe und schliesst Overlay State
+
+## Nicht enthalten
+
+- Echter Orb Canvas aus docs/index.html
+- Live Telemetrie
+- Voice Mode
+- Backend Command Routing
+- Modal Overlays fuer tiefe UIs

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,32 +1,13 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="de">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>JARVIS Windows</title>
-    <style>
-      html,body,#root{margin:0;width:100%;min-height:100%;background:#02040a;color:#e8f6ff;}
-      body{font-family:Consolas,"Courier New",monospace;}
-      #bootdiag{position:fixed;right:12px;bottom:12px;z-index:2147483647;background:rgba(0,12,24,.94);border:1px solid rgba(0,190,255,.35);border-radius:12px;padding:10px 12px;font-size:12px;color:#8ee8ff;box-shadow:0 0 24px rgba(0,180,255,.18)}
-      #bootdiag button{margin-left:8px;background:rgba(0,180,255,.18);color:#e8f6ff;border:1px solid rgba(0,180,255,.35);border-radius:8px;padding:4px 8px;cursor:pointer}
-    </style>
-    <script>
-      (function(){
-        const logs=[]; window.__JARVIS_BOOT_LOGS__=logs; window.__JARVIS_REACT_MOUNTED__=false;
-        function log(t,m){const line='['+new Date().toLocaleTimeString()+'] ['+t+'] '+m; logs.push(line); try{localStorage.setItem('jarvis_boot_log',logs.join('\n'))}catch(e){}}
-        window.__JARVIS_BOOT_LOG__=log; log('INFO','index.html geladen');
-        window.addEventListener('error',e=>log('ERROR',(e.message||'error')+' '+(e.filename||'')+':'+(e.lineno||'')));
-        window.addEventListener('unhandledrejection',e=>log('PROMISE',(e.reason&&e.reason.stack)||String(e.reason)));
-        window.__JARVIS_COPY_BOOT_LOG__=function(){navigator.clipboard&&navigator.clipboard.writeText(localStorage.getItem('jarvis_boot_log')||logs.join('\n'))}
-      })();
-    </script>
+    <meta name="theme-color" content="#000000" />
+    <title>JARVIS v18 F1 Foundation</title>
   </head>
   <body>
     <div id="root"></div>
-    <div id="bootdiag">JARVIS lädt <button onclick="location.href='/diagnose.html'">Diagnose</button><button onclick="window.__JARVIS_COPY_BOOT_LOG__&&window.__JARVIS_COPY_BOOT_LOG__()">Log kopieren</button></div>
-    <script type="module" src="/src/upload-bridge.ts"></script>
-    <script type="module" src="/src/diagnostics-bridge.ts"></script>
-    <script type="module" src="/src/knowledge-bridge.ts"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,14 +10,16 @@
     "preview": "vite preview --host 127.0.0.1 --port 4173"
   },
   "dependencies": {
-    "@vitejs/plugin-react": "^4.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "three": "^0.184.0",
     "zustand": "^4.5.5"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
+    "@types/three": "^0.184.0",
+    "@vitejs/plugin-react": "^4.2.0",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jarvis-windows-standalone",
-  "version": "B6.6.30",
-  "description": "JARVIS Windows Standalone - local first HUD, LifeOS, DiagCenter, release installer and automation audit frontend",
+  "version": "v18_F1_FOUNDATION",
+  "description": "JARVIS v18 F1 Foundation - Iron Man suit interface shell with command bus",
   "main": "electron/main.js",
   "scripts": {
     "dev": "vite --host 127.0.0.1 --port 5173",
@@ -10,15 +10,17 @@
     "preview": "vite preview --host 127.0.0.1 --port 4173"
   },
   "dependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "three": "^0.184.0"
+    "zustand": "^4.5.5"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
-    "@types/three": "^0.184.0",
-    "@vitejs/plugin-react": "^4.2.0",
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^3.4.17",
     "typescript": "^5.3.0",
     "vite": "^5.0.0"
   }

--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/components/Dialog/CommandHistory.tsx
+++ b/frontend/src/components/Dialog/CommandHistory.tsx
@@ -1,0 +1,20 @@
+import type { DialogHistoryEntry } from "../../core/types";
+
+type CommandHistoryProps = {
+  history: DialogHistoryEntry[];
+};
+
+export function CommandHistory({ history }: CommandHistoryProps) {
+  if (history.length === 0) return null;
+
+  return (
+    <aside className="command-history" aria-label="Command history">
+      {history.slice(0, 3).map((entry) => (
+        <div key={`${entry.timestamp}-${entry.input}`}>
+          <span>{entry.input}</span>
+          <small>{entry.result.message}</small>
+        </div>
+      ))}
+    </aside>
+  );
+}

--- a/frontend/src/components/Dialog/DialogInput.tsx
+++ b/frontend/src/components/Dialog/DialogInput.tsx
@@ -1,0 +1,122 @@
+import { KeyboardEvent, RefObject, useMemo, useState } from "react";
+import { CommandBus } from "../../core/CommandBus";
+import { useUiStore } from "../../state/uiStore";
+import { SuggestionDropdown } from "./SuggestionDropdown";
+import { CommandHistory } from "./CommandHistory";
+
+type DialogInputProps = {
+  bus: CommandBus;
+  inputRef: RefObject<HTMLInputElement>;
+};
+
+export function DialogInput({ bus, inputRef }: DialogInputProps) {
+  const history = useUiStore((state) => state.history);
+  const pushHistory = useUiStore((state) => state.pushHistory);
+  const clearHistory = useUiStore((state) => state.clearHistory);
+  const setInputFocused = useUiStore((state) => state.setInputFocused);
+  const [value, setValue] = useState("");
+  const [activeSuggestion, setActiveSuggestion] = useState(0);
+  const [historyIndex, setHistoryIndex] = useState(-1);
+
+  const suggestions = useMemo(() => bus.getSuggestions(value), [bus, value]);
+
+  async function submit(input: string) {
+    const clean = input.trim();
+    if (!clean) return;
+
+    if (clean === "/clear") {
+      const result = await bus.execute(clean, "text");
+      clearHistory();
+      pushHistory({ input: clean, result, timestamp: Date.now() });
+      setValue("");
+      setHistoryIndex(-1);
+      return;
+    }
+
+    const result = await bus.execute(clean, "text");
+    pushHistory({ input: clean, result, timestamp: Date.now() });
+    setValue("");
+    setHistoryIndex(-1);
+  }
+
+  function pickSuggestion(command: string) {
+    setValue(`${command} `);
+    setActiveSuggestion(0);
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }
+
+  function onKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Escape") {
+      inputRef.current?.blur();
+      setInputFocused(false);
+      return;
+    }
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      if (suggestions.length > 0) {
+        setActiveSuggestion((index) => (index + 1) % suggestions.length);
+        return;
+      }
+      if (history.length > 0) {
+        const next = Math.max(-1, historyIndex - 1);
+        setHistoryIndex(next);
+        setValue(next >= 0 ? history[next].input : "");
+      }
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      if (suggestions.length > 0) {
+        setActiveSuggestion((index) => (index - 1 + suggestions.length) % suggestions.length);
+        return;
+      }
+      if (history.length > 0) {
+        const next = Math.min(history.length - 1, historyIndex + 1);
+        setHistoryIndex(next);
+        setValue(history[next].input);
+      }
+      return;
+    }
+
+    if (event.key === "Tab" && suggestions.length > 0) {
+      event.preventDefault();
+      pickSuggestion(suggestions[activeSuggestion].command);
+      return;
+    }
+
+    if (event.key === "Enter") {
+      event.preventDefault();
+      if (suggestions.length > 0 && value.trim() === "/") {
+        pickSuggestion(suggestions[activeSuggestion].command);
+        return;
+      }
+      void submit(value);
+    }
+  }
+
+  return (
+    <div className="dialog-cluster">
+      <CommandHistory history={history} />
+      <div className="dialog-slot__input-wrap">
+        <SuggestionDropdown suggestions={suggestions} activeIndex={activeSuggestion} onPick={pickSuggestion} />
+        <input
+          ref={inputRef}
+          value={value}
+          onChange={(event) => {
+            setValue(event.target.value);
+            setActiveSuggestion(0);
+          }}
+          onKeyDown={onKeyDown}
+          onFocus={() => setInputFocused(true)}
+          onBlur={() => setInputFocused(false)}
+          placeholder="Befehl oder Frage"
+          spellCheck={false}
+          autoComplete="off"
+          aria-label="JARVIS command input"
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Dialog/SuggestionDropdown.tsx
+++ b/frontend/src/components/Dialog/SuggestionDropdown.tsx
@@ -1,0 +1,30 @@
+import type { Suggestion } from "../../core/types";
+
+type SuggestionDropdownProps = {
+  suggestions: Suggestion[];
+  activeIndex: number;
+  onPick: (command: string) => void;
+};
+
+export function SuggestionDropdown({ suggestions, activeIndex, onPick }: SuggestionDropdownProps) {
+  if (suggestions.length === 0) return null;
+
+  return (
+    <div className="suggestion-dropdown" role="listbox" aria-label="Slash command suggestions">
+      {suggestions.map((item, index) => (
+        <button
+          key={item.command}
+          type="button"
+          className={index === activeIndex ? "is-active" : ""}
+          onMouseDown={(event) => {
+            event.preventDefault();
+            onPick(item.command);
+          }}
+        >
+          <span>{item.command}</span>
+          <small>{item.description}</small>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/Hud/HudCorner.tsx
+++ b/frontend/src/components/Hud/HudCorner.tsx
@@ -1,0 +1,19 @@
+import type { HudCornerPosition } from "../../core/types";
+
+type HudCornerProps = {
+  position: HudCornerPosition;
+  title: string;
+};
+
+export function HudCorner({ position, title }: HudCornerProps) {
+  const className = ["hud-corner", `hud-${position}`].join(" ");
+
+  return (
+    <section className={className} aria-label={title}>
+      <header>{title}</header>
+      <div className="hud-line" />
+      <div className="hud-line" />
+      <div className="hud-line" />
+    </section>
+  );
+}

--- a/frontend/src/components/Orb/OrbPlaceholder.tsx
+++ b/frontend/src/components/Orb/OrbPlaceholder.tsx
@@ -1,0 +1,24 @@
+import { useOrbStore } from "../../state/orbStore";
+
+export function OrbPlaceholder() {
+  const state = useOrbStore((store) => store.state);
+
+  return (
+    <div className="orb-placeholder" data-state={state} aria-label={`JARVIS orb placeholder ${state}`}>
+      <svg viewBox="0 0 200 200" role="img" aria-hidden="true">
+        <defs>
+          <radialGradient id="orb-core" cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stopColor="rgba(220,250,255,0.95)" />
+            <stop offset="38%" stopColor="rgba(0,212,255,0.36)" />
+            <stop offset="72%" stopColor="rgba(0,90,140,0.18)" />
+            <stop offset="100%" stopColor="rgba(0,0,0,0)" />
+          </radialGradient>
+        </defs>
+        <circle cx="100" cy="100" r="78" fill="url(#orb-core)" />
+        <circle cx="100" cy="100" r="88" fill="none" stroke="rgba(0,212,255,0.38)" strokeWidth="1" />
+        <circle cx="100" cy="100" r="58" fill="none" stroke="rgba(0,212,255,0.22)" strokeWidth="1" />
+      </svg>
+      <span>{state.toUpperCase()}</span>
+    </div>
+  );
+}

--- a/frontend/src/core/CommandBus.ts
+++ b/frontend/src/core/CommandBus.ts
@@ -1,0 +1,65 @@
+import type { CommandHandler, CommandObject, CommandResult, ParsedCommand, Suggestion } from "./types";
+
+export class CommandBus {
+  private handlers = new Map<string, CommandHandler>();
+  private suggestions = new Map<string, Suggestion>();
+
+  register(command: string, handler: CommandHandler, suggestion?: Omit<Suggestion, "command">) {
+    const normalized = this.normalizeCommand(command);
+    this.handlers.set(normalized, handler);
+    this.suggestions.set(normalized, {
+      command: normalized,
+      label: suggestion?.label ?? normalized,
+      description: suggestion?.description ?? "Command stub",
+    });
+  }
+
+  parse(input: string, source: CommandObject["source"] = "text"): ParsedCommand {
+    const raw = input.trim();
+    const parts = raw.split(/\s+/).filter(Boolean);
+    const first = parts[0] ?? "";
+    const isSlashCommand = first.startsWith("/");
+    const command = isSlashCommand ? this.normalizeCommand(first) : "text";
+    const args = isSlashCommand ? parts.slice(1) : parts;
+
+    return {
+      raw,
+      command,
+      args,
+      source,
+      timestamp: Date.now(),
+      isSlashCommand,
+    };
+  }
+
+  async execute(input: string, source: CommandObject["source"] = "text"): Promise<CommandResult> {
+    const parsed = this.parse(input, source);
+    const handler = this.handlers.get(parsed.command);
+
+    if (!handler) {
+      return {
+        ok: false,
+        command: parsed.command,
+        message: parsed.isSlashCommand
+          ? `Unknown command: ${parsed.command}`
+          : "Text input captured. Backend binding follows in a later block.",
+        payload: parsed,
+      };
+    }
+
+    return handler(parsed);
+  }
+
+  getSuggestions(partial: string): Suggestion[] {
+    const value = partial.trim().toLowerCase();
+    if (!value.startsWith("/")) return [];
+
+    return Array.from(this.suggestions.values())
+      .filter((item) => item.command.startsWith(value))
+      .sort((a, b) => a.command.localeCompare(b.command));
+  }
+
+  private normalizeCommand(command: string) {
+    return command.startsWith("/") ? command.toLowerCase() : `/${command.toLowerCase()}`;
+  }
+}

--- a/frontend/src/core/CommandRegistry.ts
+++ b/frontend/src/core/CommandRegistry.ts
@@ -1,0 +1,41 @@
+import { CommandBus } from "./CommandBus";
+import type { CommandResult } from "./types";
+
+const F1_COMMANDS = [
+  ["/help", "Help", "Show available commands"],
+  ["/clear", "Clear", "Clear command history"],
+  ["/agents", "Agents", "Open agents overlay in a later block"],
+  ["/tools", "Tools", "Open tools overlay in a later block"],
+  ["/audit", "Audit", "Open audit overlay in a later block"],
+  ["/diag", "Diagnostics", "Open diagnostics overlay in a later block"],
+  ["/settings", "Settings", "Open settings overlay in a later block"],
+  ["/sap", "SAP", "Route to SAP workspace in a later block"],
+  ["/vde", "VDE", "Route to VDE workspace in a later block"],
+  ["/knowledge", "Knowledge", "Route to knowledge workspace in a later block"],
+  ["/work", "Work", "Route to work command workspace in a later block"],
+] as const;
+
+export function createCommandBus() {
+  const bus = new CommandBus();
+
+  for (const [command, label, description] of F1_COMMANDS) {
+    bus.register(
+      command,
+      (input): CommandResult => {
+        const result: CommandResult = {
+          ok: true,
+          command,
+          message: `${command} accepted as F1 stub`,
+          payload: input,
+        };
+        console.log("[JARVIS:F1:COMMAND]", result);
+        return result;
+      },
+      { label, description },
+    );
+  }
+
+  return bus;
+}
+
+export const registeredCommandNames = F1_COMMANDS.map(([command]) => command);

--- a/frontend/src/core/WebSocketClient.ts
+++ b/frontend/src/core/WebSocketClient.ts
@@ -1,0 +1,40 @@
+import type { WebSocketChannel } from "./types";
+
+export type WebSocketClientOptions = {
+  channel: WebSocketChannel;
+  onMessage: (payload: unknown) => void;
+  onOpen?: () => void;
+  onClose?: () => void;
+  onError?: (event: Event) => void;
+};
+
+export class WebSocketClient {
+  private socket: WebSocket | null = null;
+
+  constructor(private readonly options: WebSocketClientOptions) {}
+
+  connect() {
+    if (this.socket) return;
+    const protocol = window.location.protocol === "https:" ? "wss" : "ws";
+    const url = `${protocol}://${window.location.host}${this.options.channel}`;
+    this.socket = new WebSocket(url);
+    this.socket.onopen = () => this.options.onOpen?.();
+    this.socket.onclose = () => {
+      this.socket = null;
+      this.options.onClose?.();
+    };
+    this.socket.onerror = (event) => this.options.onError?.(event);
+    this.socket.onmessage = (event) => {
+      try {
+        this.options.onMessage(JSON.parse(event.data));
+      } catch {
+        this.options.onMessage(event.data);
+      }
+    };
+  }
+
+  disconnect() {
+    this.socket?.close();
+    this.socket = null;
+  }
+}

--- a/frontend/src/core/types.ts
+++ b/frontend/src/core/types.ts
@@ -1,0 +1,38 @@
+export type CommandSource = "text" | "voice" | "hotkey";
+export type OrbState = "idle" | "listening" | "thinking" | "speaking" | "error";
+export type HudCornerPosition = "top-left" | "top-right" | "bottom-left" | "bottom-right";
+
+export type CommandObject = {
+  raw: string;
+  command: string;
+  args: string[];
+  source: CommandSource;
+  timestamp: number;
+};
+
+export type ParsedCommand = CommandObject & {
+  isSlashCommand: boolean;
+};
+
+export type CommandResult = {
+  ok: boolean;
+  command: string;
+  message: string;
+  payload?: unknown;
+};
+
+export type Suggestion = {
+  command: string;
+  label: string;
+  description: string;
+};
+
+export type CommandHandler = (command: CommandObject) => Promise<CommandResult> | CommandResult;
+
+export type DialogHistoryEntry = {
+  input: string;
+  result: CommandResult;
+  timestamp: number;
+};
+
+export type WebSocketChannel = "/telemetry" | "/audit" | "/orb-state";

--- a/frontend/src/hooks/useCommandBus.ts
+++ b/frontend/src/hooks/useCommandBus.ts
@@ -1,0 +1,6 @@
+import { useMemo } from "react";
+import { createCommandBus } from "../core/CommandRegistry";
+
+export function useCommandBus() {
+  return useMemo(() => createCommandBus(), []);
+}

--- a/frontend/src/hooks/useHotkeys.ts
+++ b/frontend/src/hooks/useHotkeys.ts
@@ -1,0 +1,34 @@
+import { RefObject, useEffect } from "react";
+import { useUiStore } from "../state/uiStore";
+
+type UseHotkeysArgs = {
+  inputRef: RefObject<HTMLInputElement>;
+};
+
+export function useHotkeys({ inputRef }: UseHotkeysArgs) {
+  const closeOverlay = useUiStore((state) => state.closeOverlay);
+  const setInputFocused = useUiStore((state) => state.setInputFocused);
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      const key = event.key.toLowerCase();
+      const commandFocus = (event.ctrlKey || event.metaKey) && key === "k";
+
+      if (commandFocus) {
+        event.preventDefault();
+        inputRef.current?.focus();
+        setInputFocused(true);
+        return;
+      }
+
+      if (event.key === "Escape") {
+        closeOverlay();
+        inputRef.current?.blur();
+        setInputFocused(false);
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [closeOverlay, inputRef, setInputFocused]);
+}

--- a/frontend/src/layout/DialogSlot.tsx
+++ b/frontend/src/layout/DialogSlot.tsx
@@ -1,0 +1,16 @@
+import { RefObject } from "react";
+import { CommandBus } from "../core/CommandBus";
+import { DialogInput } from "../components/Dialog/DialogInput";
+
+type DialogSlotProps = {
+  bus: CommandBus;
+  inputRef: RefObject<HTMLInputElement>;
+};
+
+export function DialogSlot({ bus, inputRef }: DialogSlotProps) {
+  return (
+    <section className="dialog-slot" aria-label="JARVIS command dialog">
+      <DialogInput bus={bus} inputRef={inputRef} />
+    </section>
+  );
+}

--- a/frontend/src/layout/HudSlot.tsx
+++ b/frontend/src/layout/HudSlot.tsx
@@ -1,0 +1,12 @@
+import { HudCorner } from "../components/Hud/HudCorner";
+
+export function HudSlot() {
+  return (
+    <div className="hud-slot" aria-label="JARVIS HUD corner placeholders">
+      <HudCorner position="top-left" title="SYSTEM" />
+      <HudCorner position="top-right" title="NETWORK" />
+      <HudCorner position="bottom-left" title="AUDIT" />
+      <HudCorner position="bottom-right" title="TOOLS" />
+    </div>
+  );
+}

--- a/frontend/src/layout/OrbSlot.tsx
+++ b/frontend/src/layout/OrbSlot.tsx
@@ -1,0 +1,9 @@
+import { OrbPlaceholder } from "../components/Orb/OrbPlaceholder";
+
+export function OrbSlot() {
+  return (
+    <main className="orb-slot" aria-label="JARVIS orb center slot">
+      <OrbPlaceholder />
+    </main>
+  );
+}

--- a/frontend/src/layout/RootLayout.tsx
+++ b/frontend/src/layout/RootLayout.tsx
@@ -1,0 +1,21 @@
+import { useRef } from "react";
+import { useCommandBus } from "../hooks/useCommandBus";
+import { useHotkeys } from "../hooks/useHotkeys";
+import { DialogSlot } from "./DialogSlot";
+import { HudSlot } from "./HudSlot";
+import { OrbSlot } from "./OrbSlot";
+
+export function RootLayout() {
+  const bus = useCommandBus();
+  const inputRef = useRef<HTMLInputElement>(null);
+  useHotkeys({ inputRef });
+
+  return (
+    <div className="jarvis-v18-root">
+      <div className="jarvis-v18-background" />
+      <HudSlot />
+      <OrbSlot />
+      <DialogSlot bus={bus} inputRef={inputRef} />
+    </div>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { App } from "./App";
+import { RootLayout } from "./layout/RootLayout";
 import "./styles/globals.css";
 import "./styles/vignette.css";
 
@@ -12,6 +12,6 @@ if (!root) {
 
 createRoot(root).render(
   <StrictMode>
-    <App />
+    <RootLayout />
   </StrictMode>,
 );

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,102 +1,17 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import "./diagnostics/logger";
-import { addJarvisLog } from "./diagnostics/logger";
-import { ErrorBoundary } from "./components/ErrorBoundary";
-import { DiagnosticsOverlay } from "./components/DiagnosticsOverlay";
-import { SafeMode } from "./components/SafeMode";
+import { App } from "./App";
+import "./styles/globals.css";
+import "./styles/vignette.css";
 
-function markMounted() {
-  try {
-    (window as any).__JARVIS_REACT_MOUNTED__ = true;
-    const d = document.getElementById("bootdiag");
-    if (d) d.style.display = "none";
-    const bootLog = (window as any).__JARVIS_BOOT_LOG__;
-    if (typeof bootLog === "function") bootLog("INFO", "React gemountet");
-  } catch {}
+const root = document.getElementById("root");
+
+if (!root) {
+  throw new Error("JARVIS root element was not found.");
 }
 
-function FatalBootError({ error }: { error: unknown }) {
-  const err = error instanceof Error ? error : new Error(String(error));
-  return (
-    <div style={{ minHeight: "100vh", background: "#02040a", color: "#e8f6ff", padding: 24, fontFamily: "Consolas, monospace" }}>
-      <h1 style={{ color: "#7ee7ff" }}>JARVIS Frontend Fehler</h1>
-      <p>Die OberflÃ¤che konnte nicht sauber geladen werden. Der Fehler steht unten und wurde im Diagnose Log gespeichert.</p>
-      <pre style={{ whiteSpace: "pre-wrap", background: "rgba(255,0,80,.12)", border: "1px solid rgba(255,0,80,.35)", padding: 16, borderRadius: 12 }}>{err.name}: {err.message}{"\n"}{err.stack}</pre>
-      <button onClick={() => { localStorage.clear(); location.href = "/?safe=1"; }} style={{ background: "rgba(0,180,255,.18)", color: "#e8f6ff", border: "1px solid rgba(0,180,255,.45)", borderRadius: 10, padding: "10px 14px", cursor: "pointer" }}>Storage lÃ¶schen und Safe Mode</button>
-      <button onClick={() => { location.href = "/diagnose.html"; }} style={{ marginLeft: 8, background: "rgba(0,180,255,.18)", color: "#e8f6ff", border: "1px solid rgba(0,180,255,.45)", borderRadius: 10, padding: "10px 14px", cursor: "pointer" }}>Statische Diagnose</button>
-    </div>
-  );
-}
-
-function runBootSequence(): Promise<void> {
-  const params = new URLSearchParams(location.search);
-  if (params.has("noboot") || localStorage.getItem("jarvis_boot_disabled") === "1") return Promise.resolve();
-
-  return new Promise((resolve) => {
-    let done = false;
-    const overlay = document.createElement("div");
-    overlay.className = "jarvis-command-grid-boot-host";
-    overlay.innerHTML = `
-      <iframe class="jarvis-command-grid-boot-frame" src="/jarvis-command-grid-boot.html" title="JARVIS Bootsequenz"></iframe>
-      <button class="jarvis-command-grid-boot-skip" type="button">BOOT UEBERSPRINGEN</button>
-    `;
-
-    const style = document.createElement("style");
-    style.id = "jarvis-command-grid-boot-host-style";
-    style.textContent = `
-      .jarvis-command-grid-boot-host{position:fixed;inset:0;z-index:2147483000;background:#000814;overflow:hidden;transition:opacity .55s ease,transform .55s ease}
-      .jarvis-command-grid-boot-host.is-out{opacity:0;transform:scale(1.012);pointer-events:none}
-      .jarvis-command-grid-boot-frame{position:absolute;inset:0;width:100%;height:100%;border:0;background:#000814}
-      .jarvis-command-grid-boot-skip{position:absolute;right:28px;bottom:24px;z-index:2;border:1px solid rgba(0,212,255,.35);border-radius:999px;background:rgba(0,8,20,.68);color:rgba(220,250,255,.82);font:11px Consolas,monospace;letter-spacing:2px;padding:10px 14px;cursor:pointer;backdrop-filter:blur(10px);box-shadow:0 0 22px rgba(0,212,255,.16)}
-      .jarvis-command-grid-boot-skip:hover{color:#fff;border-color:rgba(0,212,255,.72);box-shadow:0 0 30px rgba(0,212,255,.28)}
-    `;
-
-    function finish() {
-      if (done) return;
-      done = true;
-      window.removeEventListener("message", onMessage);
-      overlay.classList.add("is-out");
-      setTimeout(() => {
-        overlay.remove();
-        resolve();
-      }, 580);
-    }
-
-    function onMessage(event: MessageEvent) {
-      const data = event.data as { type?: string } | undefined;
-      if (data?.type === "jarvis-command-grid-boot-complete") finish();
-    }
-
-    window.addEventListener("message", onMessage);
-    overlay.querySelector("button")?.addEventListener("click", finish);
-    if (!document.getElementById(style.id)) document.head.appendChild(style);
-    document.body.appendChild(overlay);
-    setTimeout(finish, 11000);
-  });
-}
-async function boot() {
-  const root = document.getElementById("root");
-  if (!root) return;
-  try {
-    const params = new URLSearchParams(location.search);
-    const safe = params.has("safe") || localStorage.getItem("jarvis_safe_mode") === "1";
-    addJarvisLog("info", "boot", safe ? "Safe Mode" : "Normale App");
-    if (safe) {
-      createRoot(root).render(<StrictMode><SafeMode /><DiagnosticsOverlay /></StrictMode>);
-      setTimeout(markMounted, 50);
-      return;
-    }
-    await runBootSequence();
-    const mod = await import("./App");
-    const App = mod.App;
-    createRoot(root).render(<StrictMode><ErrorBoundary><App /></ErrorBoundary><DiagnosticsOverlay /></StrictMode>);
-    setTimeout(markMounted, 50);
-  } catch (error) {
-    addJarvisLog("error", "boot", error);
-    createRoot(root).render(<StrictMode><FatalBootError error={error} /><DiagnosticsOverlay /></StrictMode>);
-    setTimeout(markMounted, 50);
-  }
-}
-
-boot();
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/frontend/src/state/orbStore.ts
+++ b/frontend/src/state/orbStore.ts
@@ -1,0 +1,12 @@
+import { create } from "zustand";
+import type { OrbState } from "../core/types";
+
+type OrbStore = {
+  state: OrbState;
+  setState: (state: OrbState) => void;
+};
+
+export const useOrbStore = create<OrbStore>((set) => ({
+  state: "idle",
+  setState: (state) => set({ state }),
+}));

--- a/frontend/src/state/uiStore.ts
+++ b/frontend/src/state/uiStore.ts
@@ -1,0 +1,24 @@
+import { create } from "zustand";
+import type { DialogHistoryEntry } from "../core/types";
+
+type UiStore = {
+  inputFocused: boolean;
+  activeOverlay: string | null;
+  history: DialogHistoryEntry[];
+  setInputFocused: (focused: boolean) => void;
+  openOverlay: (overlay: string) => void;
+  closeOverlay: () => void;
+  pushHistory: (entry: DialogHistoryEntry) => void;
+  clearHistory: () => void;
+};
+
+export const useUiStore = create<UiStore>((set) => ({
+  inputFocused: false,
+  activeOverlay: null,
+  history: [],
+  setInputFocused: (focused) => set({ inputFocused: focused }),
+  openOverlay: (overlay) => set({ activeOverlay: overlay }),
+  closeOverlay: () => set({ activeOverlay: null }),
+  pushHistory: (entry) => set((state) => ({ history: [entry, ...state.history].slice(0, 30) })),
+  clearHistory: () => set({ history: [] }),
+}));

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1,0 +1,301 @@
+@import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap");
+
+:root {
+  --j-cyan: #00d4ff;
+  --j-bg: #000000;
+  --j-text: rgba(230, 248, 255, 0.92);
+  --j-muted: rgba(138, 170, 189, 0.68);
+  --j-line: rgba(0, 212, 255, 0.2);
+  --j-glow: 0 0 22px rgba(0, 212, 255, 0.24), 0 0 60px rgba(0, 212, 255, 0.08);
+  font-family: "JetBrains Mono", Consolas, "Courier New", monospace;
+  background: #000;
+  color: var(--j-text);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: #000;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+.jarvis-v18-root {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  background: var(--j-bg);
+  color: var(--j-text);
+}
+
+.jarvis-v18-background {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  background:
+    linear-gradient(rgba(0, 212, 255, 0.018) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0, 212, 255, 0.014) 1px, transparent 1px),
+    #000;
+  background-size: 64px 64px;
+  opacity: 0.42;
+}
+
+.orb-slot {
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  z-index: 20;
+  width: 50vh;
+  height: 50vh;
+  max-width: 72vw;
+  max-height: 72vw;
+  transform: translate(-50%, -50%);
+  display: grid;
+  place-items: center;
+  pointer-events: none;
+}
+
+.orb-placeholder {
+  width: 100%;
+  height: 100%;
+  display: grid;
+  place-items: center;
+  position: relative;
+  animation: orbPulse 2s ease-in-out infinite;
+  filter: drop-shadow(0 0 26px rgba(0, 212, 255, 0.42));
+}
+
+.orb-placeholder svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.orb-placeholder span {
+  position: relative;
+  z-index: 1;
+  color: rgba(220, 250, 255, 0.78);
+  font-size: clamp(10px, 1.6vh, 14px);
+  letter-spacing: 0.26em;
+  text-shadow: var(--j-glow);
+}
+
+.dialog-slot {
+  position: fixed;
+  left: 50%;
+  bottom: 80px;
+  z-index: 30;
+  width: min(640px, calc(100vw - 32px));
+  transform: translateX(-50%);
+}
+
+.dialog-cluster {
+  position: relative;
+}
+
+.dialog-slot__input-wrap {
+  position: relative;
+  height: 56px;
+  border-radius: 28px;
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid var(--j-line);
+  box-shadow: var(--j-glow), inset 0 0 32px rgba(0, 212, 255, 0.04);
+  backdrop-filter: blur(12px);
+}
+
+.dialog-slot__input-wrap input {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  outline: 0;
+  border-radius: 28px;
+  background: transparent;
+  color: var(--j-text);
+  padding: 0 24px;
+  font-size: 14px;
+  letter-spacing: 0.02em;
+}
+
+.dialog-slot__input-wrap input::placeholder {
+  color: rgba(138, 170, 189, 0.72);
+}
+
+.suggestion-dropdown {
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  bottom: calc(100% + 12px);
+  display: grid;
+  gap: 4px;
+  padding: 8px;
+  border: 1px solid rgba(0, 212, 255, 0.18);
+  border-radius: 16px;
+  background: rgba(0, 0, 0, 0.76);
+  backdrop-filter: blur(12px);
+  box-shadow: var(--j-glow);
+}
+
+.suggestion-dropdown button {
+  border: 0;
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 12px;
+  align-items: center;
+  min-height: 34px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--j-text);
+  text-align: left;
+  cursor: pointer;
+}
+
+.suggestion-dropdown button.is-active,
+.suggestion-dropdown button:hover {
+  background: rgba(0, 212, 255, 0.1);
+}
+
+.suggestion-dropdown span {
+  color: #dff8ff;
+}
+
+.suggestion-dropdown small {
+  color: var(--j-muted);
+}
+
+.command-history {
+  position: absolute;
+  left: 18px;
+  right: 18px;
+  bottom: calc(100% + 14px);
+  display: grid;
+  gap: 6px;
+  pointer-events: none;
+}
+
+.command-history div {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  color: rgba(230, 248, 255, 0.6);
+  font-size: 11px;
+}
+
+.command-history small {
+  color: rgba(0, 212, 255, 0.68);
+}
+
+.hud-slot {
+  position: fixed;
+  inset: 0;
+  z-index: 10;
+  pointer-events: none;
+}
+
+.hud-corner {
+  position: fixed;
+  width: min(280px, calc(50vw - 32px));
+  padding: 12px 14px;
+  color: rgba(190, 240, 255, 0.78);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.hud-corner header {
+  color: var(--j-cyan);
+  margin-bottom: 10px;
+  text-shadow: 0 0 12px rgba(0, 212, 255, 0.4);
+}
+
+.hud-line {
+  height: 1px;
+  margin: 8px 0;
+  background: linear-gradient(90deg, rgba(0, 212, 255, 0.52), rgba(0, 212, 255, 0.04));
+  box-shadow: 0 0 8px rgba(0, 212, 255, 0.18);
+}
+
+.hud-top-left {
+  top: 24px;
+  left: 24px;
+  border-left: 1px solid rgba(0, 212, 255, 0.22);
+}
+
+.hud-top-right {
+  top: 24px;
+  right: 24px;
+  border-right: 1px solid rgba(0, 212, 255, 0.22);
+  text-align: right;
+}
+
+.hud-bottom-left {
+  bottom: 24px;
+  left: 24px;
+  border-left: 1px solid rgba(0, 212, 255, 0.22);
+}
+
+.hud-bottom-right {
+  bottom: 24px;
+  right: 24px;
+  border-right: 1px solid rgba(0, 212, 255, 0.22);
+  text-align: right;
+}
+
+@keyframes orbPulse {
+  0%, 100% { opacity: 0.72; transform: scale(0.992); }
+  50% { opacity: 1; transform: scale(1.012); }
+}
+
+@media (max-width: 700px) {
+  .orb-slot {
+    width: 62vw;
+    height: 62vw;
+  }
+
+  .dialog-slot {
+    bottom: 28px;
+  }
+
+  .hud-corner {
+    width: min(170px, calc(50vw - 20px));
+    padding: 8px 10px;
+    font-size: 9px;
+  }
+
+  .hud-top-left,
+  .hud-bottom-left {
+    left: 12px;
+  }
+
+  .hud-top-right,
+  .hud-bottom-right {
+    right: 12px;
+  }
+
+  .hud-top-left,
+  .hud-top-right {
+    top: 12px;
+  }
+
+  .hud-bottom-left,
+  .hud-bottom-right {
+    bottom: 104px;
+  }
+
+  .suggestion-dropdown button {
+    grid-template-columns: 1fr;
+    gap: 2px;
+  }
+}

--- a/frontend/src/styles/vignette.css
+++ b/frontend/src/styles/vignette.css
@@ -1,0 +1,22 @@
+.jarvis-v18-root::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  background:
+    radial-gradient(circle at center, rgba(0, 212, 255, 0.08) 0%, rgba(0, 0, 0, 0) 34%),
+    radial-gradient(circle at center, rgba(0, 0, 0, 0) 42%, rgba(0, 0, 0, 0.72) 100%);
+}
+
+.jarvis-v18-root::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 2;
+  pointer-events: none;
+  background: linear-gradient(rgba(255,255,255,0.018) 50%, rgba(0,0,0,0.03) 50%);
+  background-size: 100% 4px;
+  opacity: 0.22;
+  mix-blend-mode: screen;
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,19 @@
+import type { Config } from "tailwindcss";
+
+export default {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        jarvis: {
+          cyan: "#00d4ff",
+          black: "#000000",
+        },
+      },
+      fontFamily: {
+        mono: ["JetBrains Mono", "Consolas", "monospace"],
+      },
+    },
+  },
+  plugins: [],
+} satisfies Config;


### PR DESCRIPTION
## Ziel

Block F1 fuer das neue JARVIS v18 Iron Man Anzug Interface.

Dieser PR strippt den sichtbaren Frontend Einstieg auf die neue Foundation Shell:

- grosser Orb Platzhalter zentriert
- Dialogfeld unten
- HUD Platzhalter in vier Ecken
- keine sichtbaren Menues, Tabs oder Sidebars im Runtime Einstieg

## Umgesetzt

### Strip und Entry

- `frontend/index.html` auf einen einzigen React Entry reduziert.
- `frontend/src/main.tsx` mountet direkt `RootLayout`.
- Alter Boot Iframe, alte Bridge Script Tags und alte sichtbare App Shell sind aus dem Runtime Pfad entfernt.

### Layout

- `RootLayout`
- `OrbSlot`
- `DialogSlot`
- `HudSlot`
- Fullscreen fixed Layout ohne Scroll
- Orb Slot 50vh x 50vh
- Dialog unten, max 640px, 80px Abstand
- Vier HUD Corner Slots mit Dummy Content

### Command Bus

- `CommandBus` mit `register`, `parse`, `execute`, `getSuggestions`
- `CommandRegistry` mit F1 Stub Commands:
  - `/help`
  - `/clear`
  - `/agents`
  - `/tools`
  - `/audit`
  - `/diag`
  - `/settings`
  - `/sap`
  - `/vde`
  - `/knowledge`
  - `/work`

### Dialog

- `DialogInput`
- `SuggestionDropdown`
- `CommandHistory`
- `/` oeffnet Suggestion Dropdown
- Enter fuehrt Command aus und leert Eingabe
- Pfeil hoch/runter navigiert Suggestions beziehungsweise History
- ESC blurrt Eingabe

### State und Hotkeys

- Zustand Store fuer UI State
- Zustand Store fuer Orb Dummy State
- `Ctrl+K` / `Cmd+K` fokussiert Eingabe
- ESC schliesst Overlay State und blurrt Eingabe

### Vorbereitet fuer Folgeblocks

- WebSocket Client Klasse fuer spaetere Channels:
  - `/telemetry`
  - `/audit`
  - `/orb-state`
- Tailwind Config und PostCSS Config als Stack Foundation

## Bewusst nicht enthalten

- Kein echter Orb Canvas aus `docs/index.html`, das kommt in F2
- Keine echte Telemetrie, das kommt in F3
- Keine Voice Integration, das kommt in F5
- Keine Modal Overlays fuer tiefe UIs, das kommt in F6
- Keine Backend Command Bindings, F1 bleibt Stub only

## Wichtiger Hinweis zur physischen Loeschung

Der Runtime Einstieg nutzt die alte UI nicht mehr. Physisch geloescht wurden die alten UI Files noch nicht, damit `npm run typecheck` nach lokalem Lockfile Update sauber bewertet werden kann. Die Loeschliste ist in `frontend/CHANGELOG.md` dokumentiert und sollte nach gruenem lokalen Build als kleiner Folgecommit umgesetzt werden.

## Zu loeschende Files nach gruenem Build

- `frontend/src/App.tsx`
- `frontend/src/jarvis-dashboard.css`
- `frontend/src/orb-legacy.css`
- `frontend/src/chat-window.css`
- alte Page und Sidebar Komponenten unter `frontend/src/components/`, sofern nur noch vom alten `App.tsx` referenziert

## Testplan

```powershell
cd frontend
npm install
npm run typecheck
npm run build
npm run dev
```

Manuell pruefen:

- Schwarzer Fullscreen mit Vignette sichtbar
- Orb Platzhalter zentriert und pulsiert
- Dialog unten, fokussierbar mit Ctrl K oder Cmd K
- `/` oeffnet Suggestions
- Enter auf Slash Command loggt `[JARVIS:F1:COMMAND]` in der Browser Console
- ESC blurrt Dialog
- Pfeil hoch/runter navigiert Suggestions und History
- Vier HUD Corner sichtbar
- Keine alten Menues, Tabs oder Sidebars sichtbar
- Mobile 375px bricht nicht

## ZIP Build

```powershell
cd frontend
npm install
npm run typecheck
npm run build
New-Item -ItemType Directory -Force -Path ..\release | Out-Null
Compress-Archive -Path .\* -DestinationPath ..\release\jarvis-v18_F1_FOUNDATION-frontend.zip -Force
```
