### PR TITLE
feat(frontend): F1 — Iron-Man shell skeleton

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties } from "react";
 import { Orb, type OrbEventSignal, type OrbState } from "./components/Orb";
+import { useLayoutMode } from "./hooks/useLayoutMode";
+import { IronManShell } from "./components/IronManShell";
 import { DashboardModules } from "./components/DashboardModules";
 import { DayStartCard } from "./components/DayStartCard";
 import { TodayScheduleCard } from "./components/TodayScheduleCard";
@@ -719,6 +721,26 @@ export function App() {
       jarvisSound.configure(true, soundVolume / 100);
       jarvisSound.play("ui_toggle");
     }
+  }
+
+  const layoutMode = useLayoutMode();
+  if (layoutMode.mode === "iron-man") {
+    return (
+      <IronManShell
+        orbState={orbState}
+        orbSignal={orbSignal}
+        typingActivity={typingActivity}
+        thinking={thinking}
+        onSwitchToClassic={() => layoutMode.setMode("classic")}
+        onSubmit={async (command) => {
+          // Naive Bridge fuer F1: Text-Eingaben gehen durch die bestehende sendMessage.
+          // F4 ersetzt das durch echtes Slash-Routing.
+          if (typeof sendMessage === "function") {
+            await sendMessage(command.raw);
+          }
+        }}
+      />
+    );
   }
 
   return (

--- a/frontend/src/components/IronManShell.tsx
+++ b/frontend/src/components/IronManShell.tsx
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Orb, type OrbEventSignal, type OrbState } from "./Orb";
+import { useCommandBus, type BusCommand } from "../hooks/useCommandBus";
+import "../styles/iron-man.css";
+
+export interface IronManShellProps {
+  orbState: OrbState;
+  orbSignal: OrbEventSignal | null;
+  typingActivity: number;
+  thinking: boolean;
+  onSwitchToClassic: () => void;
+  onSubmit?: (command: BusCommand) => void | Promise<void>;
+}
+
+export function IronManShell({
+  orbState,
+  orbSignal,
+  typingActivity,
+  thinking,
+  onSwitchToClassic,
+  onSubmit,
+}: IronManShellProps) {
+  const [input, setInput] = useState("");
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const bus = useCommandBus(async (command) => {
+    if (onSubmit) await onSubmit(command);
+  });
+
+  const submit = useCallback(async () => {
+    const value = input.trim();
+    if (!value) return;
+    setInput("");
+    await bus.dispatch(value, "text");
+  }, [input, bus]);
+
+  useEffect(() => {
+    function onKey(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        // F1 hat noch keine Modals — ESC blurrt nur den Input.
+        inputRef.current?.blur();
+        return;
+      }
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        inputRef.current?.focus();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  const lastCommand = bus.history[bus.history.length - 1];
+
+  return (
+    <div className="iron-man-shell" role="application" aria-label="JARVIS Iron Man Shell">
+      <button
+        type="button"
+        className="iron-man-mode-toggle"
+        onClick={onSwitchToClassic}
+        title="Zurueck zum klassischen Layout"
+      >
+        Classic
+      </button>
+
+      <div className="iron-man-corner tl" aria-label="System">
+        <span className="iron-man-corner-label">SYSTEM</span>
+        <span>F3 — Telemetrie folgt</span>
+      </div>
+      <div className="iron-man-corner tr" aria-label="Netzwerk">
+        <span className="iron-man-corner-label">NETZ &middot; ZEIT</span>
+        <span>F3 — Live-Kanal folgt</span>
+      </div>
+      <div className="iron-man-corner bl" aria-label="Audit-Stream">
+        <span className="iron-man-corner-label">AUDIT</span>
+        <span>F3 — Stream folgt</span>
+      </div>
+      <div className="iron-man-corner br" aria-label="Tools und Risiko">
+        <span className="iron-man-corner-label">TOOLS &middot; RISK</span>
+        <span>F3 — Live-Kanal folgt</span>
+      </div>
+
+      <div className="iron-man-orb-area">
+        <div className="iron-man-orb-frame">
+          <Orb
+            state={orbState}
+            typingActivity={typingActivity}
+            heatmapActive={thinking || orbState === "speaking"}
+            eventSignal={orbSignal}
+          />
+        </div>
+      </div>
+
+      <div className="iron-man-input-area">
+        <div className="iron-man-input-frame">
+          <input
+            ref={inputRef}
+            value={input}
+            onChange={(event) => setInput(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") void submit();
+            }}
+            placeholder="Befehl oder /slash eingeben..."
+            spellCheck={false}
+            autoFocus
+          />
+          <div className="iron-man-input-meta">
+            <span>{lastCommand ? `Letzter: ${lastCommand.raw}` : "Strg+K fokussiert"}</span>
+            <span>F4 — Slash-Autocomplete folgt</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useCommandBus.ts
+++ b/frontend/src/hooks/useCommandBus.ts
@@ -1,0 +1,69 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+
+export type CommandSource = "text" | "voice" | "hotkey";
+
+export interface BusCommand {
+  raw: string;
+  slash: string | null;
+  args: string;
+  source: CommandSource;
+  timestamp: number;
+}
+
+export type CommandHandler = (command: BusCommand) => void | Promise<void>;
+
+function parseInput(raw: string): { slash: string | null; args: string } {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("/")) {
+    return { slash: null, args: trimmed };
+  }
+  const space = trimmed.indexOf(" ");
+  if (space === -1) {
+    return { slash: trimmed.slice(1).toLowerCase(), args: "" };
+  }
+  return {
+    slash: trimmed.slice(1, space).toLowerCase(),
+    args: trimmed.slice(space + 1).trim(),
+  };
+}
+
+export function useCommandBus(defaultHandler?: CommandHandler) {
+  const [history, setHistory] = useState<BusCommand[]>([]);
+  const handlerRef = useRef<CommandHandler | undefined>(defaultHandler);
+
+  const setHandler = useCallback((handler: CommandHandler | undefined) => {
+    handlerRef.current = handler;
+  }, []);
+
+  const dispatch = useCallback(
+    async (raw: string, source: CommandSource = "text") => {
+      const parsed = parseInput(raw);
+      const command: BusCommand = {
+        raw,
+        slash: parsed.slash,
+        args: parsed.args,
+        source,
+        timestamp: Date.now(),
+      };
+      setHistory((prev) => [...prev.slice(-49), command]);
+      if (handlerRef.current) {
+        await handlerRef.current(command);
+      }
+      return command;
+    },
+    [],
+  );
+
+  return useMemo(
+    () => ({
+      dispatch,
+      setHandler,
+      history,
+    }),
+    [dispatch, setHandler, history],
+  );
+}
+
+export function parseSlashCommand(raw: string) {
+  return parseInput(raw);
+}

--- a/frontend/src/hooks/useLayoutMode.ts
+++ b/frontend/src/hooks/useLayoutMode.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+
+export type LayoutMode = "classic" | "iron-man";
+
+const STORAGE_KEY = "jarvis.layoutMode";
+
+function detectInitialMode(): LayoutMode {
+  if (typeof window === "undefined") return "classic";
+  const params = new URLSearchParams(window.location.search);
+  if (params.has("iron")) {
+    const v = params.get("iron");
+    if (v === null || v === "1" || v === "true") return "iron-man";
+    if (v === "0" || v === "false") return "classic";
+  }
+  if (params.has("classic")) {
+    const v = params.get("classic");
+    if (v === null || v === "1" || v === "true") return "classic";
+  }
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored === "iron-man" || stored === "classic") return stored;
+  } catch {
+    // LocalStorage kann blockiert sein, dann silent fallback.
+  }
+  return "classic";
+}
+
+export function useLayoutMode(): {
+  mode: LayoutMode;
+  setMode: (mode: LayoutMode) => void;
+  toggle: () => void;
+} {
+  const [mode, setModeState] = useState<LayoutMode>(detectInitialMode);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, mode);
+    } catch {
+      // ignore
+    }
+  }, [mode]);
+
+  return {
+    mode,
+    setMode: setModeState,
+    toggle: () => setModeState((prev) => (prev === "classic" ? "iron-man" : "classic")),
+  };
+}

--- a/frontend/src/styles/iron-man.css
+++ b/frontend/src/styles/iron-man.css
@@ -1,0 +1,131 @@
+/* F1 Iron-Man Shell Skeleton — siehe docs/FRONTEND_F_ROADMAP.md */
+.iron-man-shell {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(0, 3fr) minmax(220px, 1fr);
+  grid-template-rows: auto 1fr auto;
+  grid-template-areas:
+    "tl    .     tr"
+    ".     orb   ."
+    "bl    input br";
+  background: radial-gradient(ellipse at center, #05080d 0%, #000 100%);
+  color: var(--jv-text, #e6f1ff);
+  font-family: "JetBrains Mono", ui-monospace, "SFMono-Regular", Menlo, monospace;
+  overflow: hidden;
+}
+
+.iron-man-corner {
+  padding: 16px 20px;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--jv-text-mute, #5b6b82);
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.iron-man-corner.tl { grid-area: tl; }
+.iron-man-corner.tr { grid-area: tr; align-items: flex-end; text-align: right; }
+.iron-man-corner.bl { grid-area: bl; align-self: end; }
+.iron-man-corner.br { grid-area: br; align-self: end; align-items: flex-end; text-align: right; }
+
+.iron-man-corner-label {
+  color: var(--jv-cyan, #00d4ff);
+  font-weight: 500;
+  opacity: 0.7;
+}
+
+.iron-man-orb-area {
+  grid-area: orb;
+  display: grid;
+  place-items: center;
+  position: relative;
+  padding: 24px;
+}
+
+.iron-man-orb-frame {
+  width: clamp(280px, 50vh, 720px);
+  aspect-ratio: 1 / 1;
+  display: grid;
+  place-items: center;
+}
+
+.iron-man-input-area {
+  grid-area: input;
+  padding: 18px 24px 28px;
+  display: flex;
+  justify-content: center;
+}
+
+.iron-man-input-frame {
+  width: min(720px, 90%);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px 18px;
+  border: 1px solid rgba(0, 212, 255, 0.18);
+  border-radius: 12px;
+  background: rgba(10, 14, 20, 0.55);
+  backdrop-filter: blur(14px);
+  box-shadow: 0 0 22px rgba(0, 212, 255, 0.08);
+}
+
+.iron-man-input-frame input {
+  width: 100%;
+  background: transparent;
+  border: 0;
+  outline: 0;
+  color: var(--jv-text, #e6f1ff);
+  font: inherit;
+  font-size: 14px;
+  padding: 4px 0;
+}
+
+.iron-man-input-frame input::placeholder {
+  color: var(--jv-text-mute, #5b6b82);
+}
+
+.iron-man-input-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--jv-text-mute, #5b6b82);
+}
+
+.iron-man-mode-toggle {
+  position: fixed;
+  top: 12px;
+  right: 12px;
+  z-index: 10;
+  background: rgba(10, 14, 20, 0.6);
+  border: 1px solid rgba(0, 212, 255, 0.25);
+  color: var(--jv-cyan, #00d4ff);
+  font-family: inherit;
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  padding: 6px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  text-transform: uppercase;
+}
+
+.iron-man-mode-toggle:hover {
+  background: rgba(0, 212, 255, 0.12);
+}
+
+@media (max-width: 720px) {
+  .iron-man-shell {
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas:
+      "tl    tr"
+      "orb   orb"
+      "bl    br"
+      "input input";
+  }
+  .iron-man-orb-frame { width: 80vw; }
+}


### PR DESCRIPTION
## Summary

- Erstes Skelett fuer das Iron-Man-Layout aus der F-Roadmap (B6.6.36).
- **Default bleibt classic.** Iron-Man via `?iron=1` oder LocalStorage `jarvis.layoutMode=iron-man`.
- Vier HUD-Ecken sind Stubs mit "F3 folgt"-Hinweisen.
- Slash-Routing kommt erst in F4. F1 leitet Texteingaben aktuell durch die bestehende `sendMessage`-Bridge.

## Test plan

- [ ] `?iron=1` aktiviert das neue Layout, Orb in Mitte, Input unten, vier Eck-Stubs sichtbar.
- [ ] "Classic"-Button rechts oben kehrt zum bestehenden Layout zurueck.
- [ ] LocalStorage merkt den Mode ueber Reload hinweg.
- [ ] `?classic=1` ueberschreibt den gespeicherten Modus.
- [ ] Strg+K fokussiert den Input.
- [ ] ESC blurt den Input.
- [ ] `npm run typecheck` und `npm run build` sind gruen.
- [ ] Existierender Default-Modus rendert unveraendert, keine Regression im klassischen Layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)